### PR TITLE
fix: Color.separator 타입 불일치로 인한 dist 빌드 에러 수정

### DIFF
--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -159,7 +159,7 @@ struct PopoverView: View {
                 .fill(isEvent ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(Color.clear))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
-                        .stroke(isEvent ? Color.separator : Color.clear, lineWidth: 0.5)
+                        .stroke(isEvent ? Color(nsColor: .separatorColor) : Color.clear, lineWidth: 0.5)
                 )
         )
         .animation(.easeInOut(duration: 0.2), value: isEvent)


### PR DESCRIPTION
## Summary

- `PopoverView.swift:162`에서 `Color.separator`를 사용했으나, 이는 SwiftUI에서 `SeparatorShapeStyle` 타입으로 반환되어 `Color.clear`와 타입 불일치 발생
- `Color(nsColor: .separatorColor)`로 교체하여 명시적 `Color` 타입 사용

## Error

```
error: result values in '? :' expression have mismatching types 'SeparatorShapeStyle' and 'Color'
    .stroke(isEvent ? Color.separator : Color.clear, lineWidth: 0.5)
```

## Test plan

- [ ] `make dist` 빌드 성공 확인
- [ ] 말풍선 이벤트 활성 시 테두리 색상 정상 표시 확인

https://claude.ai/code/session_016129dZSi3MgAPdMQNfSpfF

---
_Generated by [Claude Code](https://claude.ai/code/session_016129dZSi3MgAPdMQNfSpfF)_