### PR TITLE
fix: resolve equipment list scroll padding, unequip update, and item spacing issues

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -314,13 +314,17 @@ final class PetViewModel: ObservableObject {
     // MARK: - Equipment
 
     func equip(itemId: String) {
-        if inventoryManager.equip(itemId: itemId, state: &state) {
+        var updated = state
+        if inventoryManager.equip(itemId: itemId, state: &updated) {
+            state = updated
             save()
         }
     }
 
     func unequip(slot: EquipmentSlot) {
-        inventoryManager.unequip(slot: slot, state: &state)
+        var updated = state
+        inventoryManager.unequip(slot: slot, state: &updated)
+        state = updated
         save()
     }
 

--- a/Sources/DamagochiApp/Views/InventoryView.swift
+++ b/Sources/DamagochiApp/Views/InventoryView.swift
@@ -43,6 +43,7 @@ struct InventoryView: View {
                 allItemsSection
             }
             .padding(10)
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -94,14 +95,13 @@ struct InventoryView: View {
                 }
             }
 
-            if item != nil {
-                Button("해제") {
-                    viewModel.unequip(slot: slot)
-                }
-                .font(.system(size: 9))
-                .foregroundStyle(.red)
-                .buttonStyle(.plain)
+            Button("해제") {
+                if item != nil { viewModel.unequip(slot: slot) }
             }
+            .font(.system(size: 9))
+            .foregroundStyle(.red)
+            .buttonStyle(.plain)
+            .opacity(item != nil ? 1 : 0)
         }
         .frame(maxWidth: .infinity)
     }
@@ -112,7 +112,7 @@ struct InventoryView: View {
                 .font(.caption.bold())
                 .foregroundStyle(.secondary)
 
-            LazyVStack(spacing: 4) {
+            VStack(spacing: 0) {
                 ForEach(viewModel.state.inventory) { item in
                     ItemRow(item: item, isEquipped: isItemEquipped(item)) {
                         if isItemEquipped(item) {


### PR DESCRIPTION
- Fix scroll view bottom padding flickering by adding frame(maxWidth: .infinity) to scroll content
- Fix equippedSlotCard height inconsistency by always rendering the 해제 button with opacity instead of conditionally adding/removing it
- Fix list not updating after unequip by using explicit state reassignment to ensure @Published fires objectWillChange
- Replace LazyVStack(spacing: 4) with VStack(spacing: 0) to remove gaps between inventory items and ensure consistent re-rendering

https://claude.ai/code/session_01B1ispeiggFbibhKZriXhaf