### PR TITLE
feat: brew upgrade로 자동 업데이트 및 앱 재시작 기능 추가

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -59,6 +59,8 @@ final class PetViewModel: ObservableObject {
     private var bugCleanupTimer: AnyCancellable?
     @Published var latestVersion: String?
     @Published var isCheckingUpdate: Bool = false
+    @Published var isUpdating: Bool = false
+    @Published var updateError: String?
     @Published var isWalking: Bool = false
     @Published var walkSpeechBubble: String?
     @Published var walkNotifications: [WalkNotification] = []
@@ -546,10 +548,60 @@ final class PetViewModel: ObservableObject {
         return latest.compare(current, options: .numeric) == .orderedDescending
     }
 
-    func openReleasePage() {
-        if let url = URL(string: "https://github.com/keepbang/damagochi/releases/latest") {
-            NSWorkspace.shared.open(url)
+    func performBrewUpdate() {
+        guard !isUpdating else { return }
+        isUpdating = true
+        updateError = nil
+
+        Task.detached(priority: .userInitiated) {
+            let brewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
+            guard let brewPath = brewPaths.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
+                await MainActor.run {
+                    self.isUpdating = false
+                    self.updateError = "Homebrew를 찾을 수 없습니다."
+                }
+                return
+            }
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: brewPath)
+            process.arguments = ["upgrade", "--cask", "keepbang/tap/damagochi"]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+
+                let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outputData, encoding: .utf8) ?? ""
+
+                await MainActor.run {
+                    self.isUpdating = false
+                    if process.terminationStatus == 0 {
+                        self.restartApp()
+                    } else {
+                        self.updateError = output.isEmpty ? "업데이트에 실패했습니다." : output
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self.isUpdating = false
+                    self.updateError = "업데이트 실행 실패: \(error.localizedDescription)"
+                }
+            }
         }
+    }
+
+    private func restartApp() {
+        let appPath = Bundle.main.bundlePath
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sleep 2 && open '\(appPath)'"]
+        try? process.run()
+        NSApp.terminate(nil)
     }
 
     private func save() {

--- a/Sources/DamagochiApp/Views/SettingsView.swift
+++ b/Sources/DamagochiApp/Views/SettingsView.swift
@@ -15,13 +15,13 @@ struct SettingsView: View {
                 Text("v\(appVersion)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                if viewModel.isCheckingUpdate {
+                if viewModel.isCheckingUpdate || viewModel.isUpdating {
                     ProgressView()
                         .scaleEffect(0.6)
                         .padding(.leading, 4)
                 } else if viewModel.hasUpdate, let latest = viewModel.latestVersion {
                     Button("v\(latest) 업데이트") {
-                        viewModel.openReleasePage()
+                        viewModel.performBrewUpdate()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.mini)
@@ -202,7 +202,27 @@ struct SettingsView: View {
             infoRow("버전", value: appVersion)
             infoRow("플랫폼", value: "macOS 14+")
 
-            if viewModel.hasUpdate, let latest = viewModel.latestVersion {
+            if viewModel.isUpdating {
+                HStack {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                    Text("Homebrew로 업데이트 중...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else if let error = viewModel.updateError {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                    Text(error)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .lineLimit(3)
+                    Spacer()
+                }
+            } else if viewModel.hasUpdate, let latest = viewModel.latestVersion {
                 HStack {
                     Image(systemName: "arrow.up.circle.fill")
                         .foregroundStyle(.green)
@@ -212,7 +232,7 @@ struct SettingsView: View {
                         .foregroundStyle(.green)
                     Spacer()
                     Button("업데이트") {
-                        viewModel.openReleasePage()
+                        viewModel.performBrewUpdate()
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.mini)


### PR DESCRIPTION
업데이트 버튼 클릭 시 GitHub 릴리즈 페이지를 여는 대신
`brew upgrade --cask keepbang/tap/damagochi`를 실행하고
성공 시 앱을 자동으로 재시작합니다.

업데이트 진행 중에는 스피너를 표시하고, 실패 시 오류 메시지를
인라인으로 표시합니다.

https://claude.ai/code/session_017KFbFsBUAYjHHWoYzF7M3V