### PR TITLE
fix: 스트릭 알람 중복 발송 및 0→2일 점프 버그 수정

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -428,6 +428,8 @@ final class PetViewModel: ObservableObject {
             if milestones.contains(result.newStreakDays) {
                 showNotification("🎉 \(result.newStreakDays)일 스트릭 달성!", icon: "flame.fill")
                 sendSystemNotification { $0.sendStreakMilestone(days: result.newStreakDays) }
+            } else if result.newStreakDays == 1 {
+                showNotification("🔥 코딩 스트릭 시작!", icon: "flame")
             } else if result.newStreakDays > 1 {
                 showNotification("🔥 \(result.newStreakDays)일 연속 코딩!", icon: "flame")
             }

--- a/Sources/DamagochiCore/Events/FeedProcessor.swift
+++ b/Sources/DamagochiCore/Events/FeedProcessor.swift
@@ -63,9 +63,9 @@ public struct FeedProcessor: Sendable {
         var streakUpdated = false
         var newStreakDays = 0
         if case .sessionStart = event.kind {
-            let prevStreak = state.streakDays
+            let prevLastDate = state.lastStreakDate
             updateStreak(state: &state, now: event.timestamp)
-            if state.streakDays != prevStreak || state.lastStreakDate != nil {
+            if state.lastStreakDate != prevLastDate {
                 streakUpdated = true
                 newStreakDays = state.streakDays
             }


### PR DESCRIPTION
- FeedProcessor: lastStreakDate 변경 여부로 streakUpdated 판단
  기존 `|| state.lastStreakDate != nil` 조건이 lastStreakDate가 세팅된 후
  매 세션 시작마다 streakUpdated=true를 만들어 알람이 계속 발송되던 문제 수정
- PetViewModel: 스트릭 1일째(첫 시작) 알림 추가
  newStreakDays > 1 조건에 막혀 1일이 조용히 넘어가면서 사용자가
  0일 → 2일로 점프하는 것처럼 보이던 문제 수정

https://claude.ai/code/session_01QMMrBMp5dhvWCeh1wCxUz7