### PR TITLE
fix: 업데이트 버튼 클릭 시 관리자 인증 다이얼로그 표시

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -565,9 +565,10 @@ final class PetViewModel: ObservableObject {
                 return
             }
 
+            let script = "do shell script \"\(brewPath) upgrade --cask keepbang/tap/damagochi\" with administrator privileges"
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: brewPath)
-            process.arguments = ["upgrade", "--cask", "keepbang/tap/damagochi"]
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-e", script]
 
             let pipe = Pipe()
             process.standardOutput = pipe
@@ -585,7 +586,12 @@ final class PetViewModel: ObservableObject {
                     if process.terminationStatus == 0 {
                         self.restartApp()
                     } else {
-                        self.updateError = output.isEmpty ? "업데이트에 실패했습니다." : output
+                        // osascript returns -128 when user cancels the auth dialog
+                        if process.terminationStatus == -128 {
+                            self.updateError = nil
+                        } else {
+                            self.updateError = output.isEmpty ? "업데이트에 실패했습니다." : output
+                        }
                     }
                 }
             } catch {


### PR DESCRIPTION
brew upgrade --cask는 /Applications 설치 시 관리자 권한이 필요하나
직접 Process로 실행하면 인증창이 뜨지 않아 에러 발생.
osascript의 'with administrator privileges'를 사용해 macOS 기본
인증 다이얼로그가 표시되도록 수정.

https://claude.ai/code/session_01GoFwzjdWAx9osW7N3XtyUY