### PR TITLE
fix: brew가 root로 실행되어 업데이트가 진행되지 않던 문제 수정

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -565,29 +565,41 @@ final class PetViewModel: ObservableObject {
                 return
             }
 
-            let script = "do shell script \"\(brewPath) upgrade --cask keepbang/tap/damagochi\" with administrator privileges"
+            // Run brew as the current user (not root) to avoid Homebrew's root check.
+            // The outer shell runs with administrator privileges so sudo can switch users without a password.
+            let username = NSUserName()
+            let script = "do shell script \"sudo -u '\(username)' '\(brewPath)' upgrade --cask keepbang/tap/damagochi 2>&1\" with administrator privileges"
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
             process.arguments = ["-e", script]
 
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = pipe
+            let outPipe = Pipe()
+            let errPipe = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
 
             do {
                 try process.run()
                 process.waitUntilExit()
 
-                let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: outputData, encoding: .utf8) ?? ""
+                let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = [outData, errData]
+                    .compactMap { String(data: $0, encoding: .utf8) }
+                    .joined()
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
 
                 await MainActor.run {
                     self.isUpdating = false
                     if process.terminationStatus == 0 {
                         self.restartApp()
                     } else {
-                        // osascript returns -128 when user cancels the auth dialog
-                        if process.terminationStatus == -128 {
+                        // User cancelled the authentication dialog (osascript exits with 1,
+                        // "User cancelled" in output)
+                        let cancelled = output.lowercased().contains("user cancel") ||
+                                        output.lowercased().contains("cancelled") ||
+                                        output.lowercased().contains("취소")
+                        if cancelled {
                             self.updateError = nil
                         } else {
                             self.updateError = output.isEmpty ? "업데이트에 실패했습니다." : output


### PR DESCRIPTION
osascript의 'with administrator privileges'가 brew를 root로 실행하면
Homebrew가 보안상 root 실행을 거부하여 패스워드 입력 후 업데이트가
멈추는 현상이 발생했다. sudo -u $USER 를 사용해 관리자 쉘에서
brew를 일반 사용자로 실행하도록 수정. stderr도 함께 캡처하고
사용자 취소 감지 로직도 올바르게 수정.

https://claude.ai/code/session_01W6hdwzDMj52DeppTaokiUg