### PR TITLE
feat: 경험치 아래 스탯 항목에 마우스 오버 툴팁 추가

### DIFF
--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -5,6 +5,7 @@ import DamagochiRenderer
 struct PopoverView: View {
     @ObservedObject var viewModel: PetViewModel
     @State private var showOnboarding = !UserDefaults.standard.bool(forKey: "onboardingCompleted")
+    @State private var statsTooltip: String? = nil
 
     var body: some View {
         Group {
@@ -252,21 +253,30 @@ struct PopoverView: View {
     // MARK: - Stats Row
 
     private var statsRow: some View {
-        HStack {
-            statItem(icon: "text.bubble", count: viewModel.state.totalPrompts)
-                .help("총 프롬프트 입력 횟수")
-            Spacer()
-            statItem(icon: "wrench", count: viewModel.state.totalToolUses)
-                .help("총 툴 사용 횟수 (Read, Edit, Grep 등)")
-            Spacer()
-            statItem(icon: "play.circle", count: viewModel.state.totalSessions)
-                .help("총 Claude Code 세션 시작 횟수")
-            Spacer()
-            streakItem
-                .help("연속 코딩 일수. 매일 Claude Code를 사용하면 스트릭이 유지됩니다.")
+        VStack(spacing: 4) {
+            HStack {
+                statItem(icon: "text.bubble", count: viewModel.state.totalPrompts)
+                    .onHover { statsTooltip = $0 ? "총 프롬프트 입력 횟수" : nil }
+                Spacer()
+                statItem(icon: "wrench", count: viewModel.state.totalToolUses)
+                    .onHover { statsTooltip = $0 ? "툴 사용 횟수 (Read, Edit, Grep 등)" : nil }
+                Spacer()
+                statItem(icon: "play.circle", count: viewModel.state.totalSessions)
+                    .onHover { statsTooltip = $0 ? "Claude Code 세션 시작 횟수" : nil }
+                Spacer()
+                streakItem
+                    .onHover { statsTooltip = $0 ? "연속 코딩 일수 (매일 사용 시 유지)" : nil }
+            }
+            .font(.caption)
+            .padding(.top, 2)
+
+            Text(statsTooltip ?? "")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .opacity(statsTooltip != nil ? 1 : 0)
+                .animation(.easeInOut(duration: 0.15), value: statsTooltip)
         }
-        .font(.caption)
-        .padding(.top, 2)
     }
 
     private var streakItem: some View {


### PR DESCRIPTION
각 스탯 아이콘(프롬프트, 툴, 세션, 스트릭)에 .onHover() 적용하여
호버 시 아이콘 설명 텍스트를 즉시 표시. 기존 .help() 시스템 툴팁 대비
딜레이 없이 뷰 내에서 바로 확인 가능.

https://claude.ai/code/session_01Jivez5eBXFHk1vhRuVUc8y