### PR TITLE
fix: 방생 시 장비 유지 및 알림 목록 개선 (#18, #19)

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -32,6 +32,7 @@ struct WalkNotification: Identifiable {
     let id = UUID()
     let message: String
     let timestamp: Date
+    var isRead: Bool = false
 }
 
 @MainActor
@@ -229,6 +230,12 @@ final class PetViewModel: ObservableObject {
         walkNotifications.removeAll { $0.id == id }
     }
 
+    func markWalkNotificationAsRead(id: UUID) {
+        if let idx = walkNotifications.firstIndex(where: { $0.id == id }) {
+            walkNotifications[idx].isRead = true
+        }
+    }
+
     private func applyWalkingDecay() {
         guard state.phase == .alive else { return }
         let oldHp = state.hp
@@ -263,7 +270,7 @@ final class PetViewModel: ObservableObject {
             if result.newLevel > state.level {
                 state.level = result.newLevel
                 state.xp = result.remainingXp
-                showNotification("⬆️ 레벨 \(state.level) 달성!", icon: "arrow.up.circle.fill")
+                showNotification("레벨 \(state.level) 달성!", icon: "arrow.up.circle.fill")
             } else {
                 state.xp = result.remainingXp
             }
@@ -277,7 +284,7 @@ final class PetViewModel: ObservableObject {
         let newAchievements = checker.check(state: state)
         for a in newAchievements {
             state.unlockedAchievements.append(a.id)
-            showNotification("🏆 \(a.name) 달성!", icon: "trophy.fill")
+            showNotification("\(a.name) 달성!", icon: "trophy.fill")
         }
 
         bugXPPopup = "+\(xp) XP \(bug.type.emoji)"
@@ -361,7 +368,7 @@ final class PetViewModel: ObservableObject {
             .map { $0.prefix(8).map { String(format: "%02x", $0) }.joined() }
             ?? "unknown"
         state = PetState(machineId: hostHash)
-        showNotification("🔄 앱 데이터가 초기화되었습니다.", icon: "arrow.counterclockwise")
+        showNotification("앱 데이터가 초기화되었습니다.", icon: "arrow.counterclockwise")
     }
 
     // MARK: - Release
@@ -372,12 +379,16 @@ final class PetViewModel: ObservableObject {
         let previousEntries = state.graveyardEntries
         let previousDeathCount = state.deathCount
         let previousAchievements = state.unlockedAchievements
+        let previousInventory = state.inventory
+        let previousEquippedItems = state.equippedItems
         state = PetState(machineId: state.machineId)
         state.graveyardEntries = previousEntries + [entry]
         state.deathCount = previousDeathCount
         state.unlockedAchievements = previousAchievements
+        state.inventory = previousInventory
+        state.equippedItems = previousEquippedItems
         save()
-        showNotification("🕊️ 펫을 방생했습니다. 새 알이 생겼어요!", icon: "bird.fill")
+        showNotification("펫을 방생했습니다. 새 알이 생겼어요!", icon: "bird.fill")
     }
 
     // MARK: - Rebirth
@@ -393,7 +404,7 @@ final class PetViewModel: ObservableObject {
         state.deathCount = previousDeathCount + 1
         state.unlockedAchievements = previousAchievements
         save()
-        showNotification("🔄 새로운 알이 나타났습니다!", icon: "arrow.counterclockwise.circle.fill")
+        showNotification("새로운 알이 나타났습니다!", icon: "arrow.counterclockwise.circle.fill")
     }
 
     // MARK: - Private
@@ -426,12 +437,12 @@ final class PetViewModel: ObservableObject {
         if result.streakUpdated && result.newStreakDays > 0 {
             let milestones = [7, 30, 100]
             if milestones.contains(result.newStreakDays) {
-                showNotification("🎉 \(result.newStreakDays)일 스트릭 달성!", icon: "flame.fill")
+                showNotification("\(result.newStreakDays)일 스트릭 달성!", icon: "flame.fill")
                 sendSystemNotification { $0.sendStreakMilestone(days: result.newStreakDays) }
             } else if result.newStreakDays == 1 {
-                showNotification("🔥 코딩 스트릭 시작!", icon: "flame")
+                showNotification("코딩 스트릭 시작!", icon: "flame")
             } else if result.newStreakDays > 1 {
-                showNotification("🔥 \(result.newStreakDays)일 연속 코딩!", icon: "flame")
+                showNotification("\(result.newStreakDays)일 연속 코딩!", icon: "flame")
             }
             sendSystemNotification { $0.scheduleStreakWarning(streakDays: result.newStreakDays) }
         }
@@ -443,17 +454,17 @@ final class PetViewModel: ObservableObject {
             let speciesName = speciesEntry?.name ?? "펫"
             let rarityLabel: String
             switch speciesEntry?.rarity {
-            case .common:    rarityLabel = "⬜ 커먼"
-            case .rare:      rarityLabel = "🔵 레어"
-            case .legendary: rarityLabel = "🟡 레전더리"
-            case .mythic:    rarityLabel = "🌈 미식"
+            case .common:    rarityLabel = "커먼"
+            case .rare:      rarityLabel = "레어"
+            case .legendary: rarityLabel = "레전더리"
+            case .mythic:    rarityLabel = "미식"
             case nil:        rarityLabel = ""
             }
             let suffix = rarityLabel.isEmpty ? "" : " [\(rarityLabel)]"
-            showNotification("🐣 \(speciesName)\(suffix) 부화!", icon: "sparkles")
+            showNotification("\(speciesName)\(suffix) 부화!", icon: "sparkles")
             sendSystemNotification { $0.sendHatched(speciesName: speciesName) }
         } else if state.level > oldLevel {
-            showNotification("⬆️ 레벨 \(state.level) 달성!", icon: "arrow.up.circle.fill")
+            showNotification("레벨 \(state.level) 달성!", icon: "arrow.up.circle.fill")
             sendSystemNotification { $0.sendLevelUp(level: self.state.level) }
         }
 
@@ -488,7 +499,7 @@ final class PetViewModel: ObservableObject {
             let entry = deathChecker.processDeath(state: &state)
             state.graveyardEntries.append(entry)
             save()
-            showNotification("💀 펫이 사망했습니다...", icon: "heart.slash.fill")
+            showNotification("펫이 사망했습니다...", icon: "heart.slash.fill")
             sendSystemNotification { $0.sendDeath() }
             return
         }

--- a/Sources/DamagochiApp/Views/NotificationsView.swift
+++ b/Sources/DamagochiApp/Views/NotificationsView.swift
@@ -57,13 +57,22 @@ struct NotificationsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.message)
                     .font(.caption)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(item.isRead ? .tertiary : .primary)
                 Text(relativeTime(item.timestamp))
                     .font(.caption2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.quaternary)
             }
 
             Spacer()
+
+            if !item.isRead {
+                Button("읽음") {
+                    viewModel.markWalkNotificationAsRead(id: item.id)
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .buttonStyle(.plain)
+            }
 
             Button(action: { viewModel.dismissWalkNotification(id: item.id) }) {
                 Image(systemName: "xmark")
@@ -73,7 +82,7 @@ struct NotificationsView: View {
             .buttonStyle(.plain)
         }
         .padding(8)
-        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(0.3)))
+        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(item.isRead ? 0.15 : 0.3)))
     }
 
     private func notificationIcon(_ message: String) -> String {

--- a/Tests/DamagochiIntegrationTests/IntegrationTests.swift
+++ b/Tests/DamagochiIntegrationTests/IntegrationTests.swift
@@ -198,6 +198,44 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(merged.levelsGained, 1)
     }
 
+    // MARK: - Release Flow
+
+    func testReleasePreservesEquipment() {
+        var state = PetState(machineId: "test-release")
+
+        // Hatch and gain equipment
+        for _ in 0..<20 {
+            processor.process(event: BehaviorEvent(kind: .prompt), state: &state)
+        }
+        XCTAssertEqual(state.phase, .alive)
+
+        // Level up to acquire equipment
+        for _ in 0..<20 {
+            processor.process(event: BehaviorEvent(kind: .prompt), state: &state)
+        }
+        let inventoryBeforeRelease = state.inventory
+        XCTAssertFalse(inventoryBeforeRelease.isEmpty, "Should have equipment before release")
+
+        // Simulate release: preserve inventory and equippedItems
+        let entry = GraveyardEntry(from: state, cause: "방생")
+        let previousEntries = state.graveyardEntries
+        let previousDeathCount = state.deathCount
+        let previousAchievements = state.unlockedAchievements
+        let previousInventory = state.inventory
+        let previousEquippedItems = state.equippedItems
+        state = PetState(machineId: "test-release")
+        state.graveyardEntries = previousEntries + [entry]
+        state.deathCount = previousDeathCount
+        state.unlockedAchievements = previousAchievements
+        state.inventory = previousInventory
+        state.equippedItems = previousEquippedItems
+
+        XCTAssertEqual(state.phase, .egg, "Should be egg after release")
+        XCTAssertEqual(state.level, 0, "Level resets after release")
+        XCTAssertEqual(state.inventory.count, inventoryBeforeRelease.count, "Inventory should be preserved after release")
+        XCTAssertEqual(state.graveyardEntries.last?.causeOfDeath, "방생")
+    }
+
     // MARK: - Edge Cases
 
     func testFeedingDeadPetStillRecordsStats() {


### PR DESCRIPTION
- 방생(release) 시 inventory와 equippedItems를 새 알에 그대로 이어받도록 수정
- 알림 메시지 텍스트에서 인라인 이모지 제거 (아이콘은 별도 표시)
- WalkNotification에 isRead 필드 추가
- 알림 목록 각 항목에 읽음 버튼 추가 (읽은 항목은 흐리게 표시)
- markWalkNotificationAsRead(id:) 메서드 추가
- 방생 시 장비 유지를 검증하는 통합 테스트 추가

https://claude.ai/code/session_01HghrJfn2jq4HtMqZDK9ZEq