### PR TITLE
feat: 로컬 네트워크 배틀 시스템 Phase 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
                 "DamagochiMonitor",
                 "DamagochiStorage",
                 "DamagochiRenderer",
+                "DamagochiNetwork",
             ],
             linkerSettings: [
                 .unsafeFlags(["-Xlinker", "-sectcreate", "-Xlinker", "__TEXT", "-Xlinker", "__info_plist", "-Xlinker", "Resources/Info.plist"]),
@@ -42,6 +43,10 @@ let package = Package(
         ),
         .target(
             name: "DamagochiRenderer",
+            dependencies: ["DamagochiCore"]
+        ),
+        .target(
+            name: "DamagochiNetwork",
             dependencies: ["DamagochiCore"]
         ),
         .executableTarget(

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -18,5 +18,11 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2026. All rights reserved.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>로컬 네트워크에서 상대방과 배틀하기 위해 필요합니다</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_damagochi-btl._tcp</string>
+	</array>
 </dict>
 </plist>

--- a/Sources/DamagochiApp/BattleViewModel.swift
+++ b/Sources/DamagochiApp/BattleViewModel.swift
@@ -1,0 +1,335 @@
+import Foundation
+import SwiftUI
+import DamagochiCore
+import DamagochiNetwork
+
+@MainActor
+final class BattleViewModel: ObservableObject {
+
+    // MARK: - Phase
+
+    enum Phase: Equatable {
+        case browsing
+        case connecting(peerId: String)
+        case inBattle
+        case finished(won: Bool)
+    }
+
+    enum TurnPhase {
+        case selectingSkill
+        case waitingForOpponent
+        case resolving
+    }
+
+    // MARK: - Published
+
+    @Published var phase: Phase = .browsing
+    @Published var foundPeers: [FoundPeer] = []
+    @Published var battleState: BattleState?
+    @Published var turnPhase: TurnPhase = .selectingSkill
+    @Published var lastReward: BattleReward?
+    @Published var errorMessage: String?
+    @Published var selectedSkillId: String?
+
+    struct FoundPeer: Identifiable {
+        let id: String
+        let name: String
+    }
+
+    // MARK: - Private
+
+    private let transport: LocalNetworkTransport
+    private weak var petViewModel: PetViewModel?
+    private var opponentSkillId: String?
+    private var mySkillId: String?
+    private var eventTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var myNonce: String = ""
+    private var opponentCommitHash: String?
+    private var myCommitSent = false
+
+    // MARK: - Init
+
+    init(petViewModel: PetViewModel) {
+        self.petViewModel = petViewModel
+        let name = petViewModel.state.name
+            ?? petViewModel.state.species
+            ?? petViewModel.state.machineId
+        self.transport = LocalNetworkTransport(displayName: name)
+        startListening()
+    }
+
+    deinit {
+        eventTask?.cancel()
+        timeoutTask?.cancel()
+    }
+
+    // MARK: - Actions
+
+    func startBrowsing() {
+        transport.startBrowsing()
+        phase = .browsing
+        foundPeers = []
+    }
+
+    func stopBrowsing() {
+        transport.stopBrowsing()
+    }
+
+    func invitePeer(_ peer: FoundPeer) {
+        phase = .connecting(peerId: peer.id)
+        do {
+            try transport.invite(peer.id)
+        } catch {
+            errorMessage = error.localizedDescription
+            phase = .browsing
+        }
+    }
+
+    func selectSkill(_ skillId: String) {
+        guard turnPhase == .selectingSkill else { return }
+        mySkillId = skillId
+        selectedSkillId = skillId
+        turnPhase = .waitingForOpponent
+
+        // Commit-Reveal Step 1: commit 전송
+        myNonce = CommitReveal.makeNonce()
+        let hash = CommitReveal.commit(skillId: skillId, nonce: myNonce)
+        do {
+            try transport.send(.skillCommit(hash: hash, turn: battleState?.turn ?? 1))
+            myCommitSent = true
+        } catch {
+            turnPhase = .selectingSkill
+            errorMessage = "스킬 전송 실패: \(error.localizedDescription)"
+            mySkillId = nil
+            selectedSkillId = nil
+            return
+        }
+
+        // 상대방 commit이 이미 도착한 경우 reveal 전송
+        if opponentCommitHash != nil {
+            sendReveal()
+        }
+        startTurnTimeout()
+    }
+
+    func forfeit() {
+        try? transport.send(.forfeit)
+        transport.disconnect()
+        phase = .finished(won: false)
+        applyReward(won: false)
+    }
+
+    func reset() {
+        transport.disconnect()
+        battleState = nil
+        opponentSkillId = nil
+        mySkillId = nil
+        selectedSkillId = nil
+        lastReward = nil
+        errorMessage = nil
+        opponentCommitHash = nil
+        myCommitSent = false
+        myNonce = ""
+        phase = .browsing
+        foundPeers = []
+        transport.startBrowsing()
+    }
+
+    // MARK: - Skills for current character
+
+    var mySkills: [BattleSkill] {
+        if let group = battleState?.myProfile.mbtiGroup {
+            return BattleSkill.skills(for: group)
+        }
+        guard let speciesId = petViewModel?.state.species,
+              let species = Species.allSpecies.first(where: { $0.id == speciesId })
+        else { return [] }
+        return BattleSkill.skills(for: species.group)
+    }
+
+    // MARK: - Event Listener
+
+    private func startListening() {
+        eventTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.transport.events {
+                await MainActor.run {
+                    self.handleEvent(event)
+                }
+            }
+        }
+    }
+
+    private func handleEvent(_ event: BattleTransportEvent) {
+        switch event {
+        case .peerFound(let id, let name):
+            if !foundPeers.contains(where: { $0.id == id }) {
+                foundPeers.append(FoundPeer(id: id, name: name))
+            }
+
+        case .peerLost(let id):
+            foundPeers.removeAll { $0.id == id }
+
+        case .connected:
+            sendMyProfile()
+
+        case .disconnected:
+            if phase == .inBattle {
+                errorMessage = "상대방 연결이 끊어졌습니다"
+                phase = .finished(won: true)
+                applyReward(won: true)
+            }
+
+        case .messageReceived(let msg):
+            handleMessage(msg)
+
+        case .error(let err):
+            errorMessage = err.localizedDescription
+        }
+    }
+
+    private func handleMessage(_ message: BattleMessage) {
+        switch message {
+        case .profile(let profile):
+            guard let myState = petViewModel?.state,
+                  let myProfile = BattleProfile.from(myState)
+            else { return }
+            battleState = BattleState(me: myProfile, opponent: profile)
+            phase = .inBattle
+            turnPhase = .selectingSkill
+
+        case .skillCommit(let hash, _):
+            opponentCommitHash = hash
+            // 내 commit이 이미 전송된 경우 reveal 전송
+            if myCommitSent {
+                sendReveal()
+            }
+
+        case .skillReveal(let skillId, let nonce, _):
+            // Commit-Reveal 검증: nonce로 해시 재계산하여 commit과 일치하는지 확인
+            if let commitHash = opponentCommitHash {
+                let expectedHash = CommitReveal.commit(skillId: skillId, nonce: nonce)
+                if expectedHash != commitHash {
+                    errorMessage = "상대방 스킬 검증 실패: 커밋 해시 불일치"
+                    return
+                }
+            }
+            opponentSkillId = skillId
+            tryResolveTurn()
+
+        case .battleEnd:
+            break
+
+        case .forfeit:
+            phase = .finished(won: true)
+            applyReward(won: true)
+        }
+    }
+
+    // MARK: - Commit-Reveal
+
+    private func sendReveal() {
+        guard let skillId = mySkillId else { return }
+        do {
+            try transport.send(.skillReveal(skillId: skillId, nonce: myNonce, turn: battleState?.turn ?? 1))
+        } catch {
+            errorMessage = "스킬 공개 실패: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Turn Resolution
+
+    private func tryResolveTurn() {
+        guard let myId = mySkillId, let opId = opponentSkillId,
+              var state = battleState else { return }
+
+        timeoutTask?.cancel()
+        turnPhase = .resolving
+
+        BattleEngine.resolveTurn(state: &state, mySkillId: myId, opponentSkillId: opId)
+        battleState = state
+
+        mySkillId = nil
+        opponentSkillId = nil
+        selectedSkillId = nil
+        opponentCommitHash = nil
+        myCommitSent = false
+
+        if state.status != .ongoing {
+            let won = state.status == .victory
+            let result = BattleResult(
+                winnerId: won ? state.myProfile.id : state.opponentProfile.id,
+                loserId: won ? state.opponentProfile.id : state.myProfile.id,
+                turns: state.turn,
+                log: state.log
+            )
+            try? transport.send(.battleEnd(result: result))
+            phase = .finished(won: won)
+            applyReward(won: won)
+        } else {
+            turnPhase = .selectingSkill
+        }
+    }
+
+    private func startTurnTimeout() {
+        timeoutTask?.cancel()
+        timeoutTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: .seconds(BattleTimeout.skillSelectSeconds))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                if self.opponentSkillId == nil {
+                    guard let group = self.battleState?.opponentProfile.mbtiGroup else { return }
+                    let defaultSkillId = BattleTimeout.defaultSkillId(for: group)
+                    self.opponentSkillId = defaultSkillId
+                    // 타임아웃 시: 상대방에게 기본 스킬로 reveal 전송
+                    try? self.transport.send(.skillReveal(skillId: self.mySkillId ?? BattleTimeout.defaultSkillId(for: self.battleState?.myProfile.mbtiGroup ?? group), nonce: self.myNonce, turn: self.battleState?.turn ?? 1))
+                    self.tryResolveTurn()
+                }
+            }
+        }
+    }
+
+    // MARK: - Profile Exchange
+
+    private func sendMyProfile() {
+        guard let myState = petViewModel?.state,
+              let profile = BattleProfile.from(myState) else { return }
+        do {
+            try transport.send(.profile(profile))
+        } catch {
+            errorMessage = "프로필 전송 실패: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Reward
+
+    private func applyReward(won: Bool) {
+        guard let vm = petViewModel,
+              let opRarity = battleState?.opponentProfile.speciesRarity else { return }
+
+        let allEquip = EquipmentDropper.itemPool
+        let reward = BattleEngine.calcReward(
+            won: won,
+            myLevel: vm.state.level,
+            opponentRarity: opRarity,
+            allEquipment: allEquip
+        )
+        lastReward = reward
+        vm.applyBattleReward(reward)
+    }
+}
+
+// MARK: - PetViewModel 확장
+
+extension PetViewModel {
+    func applyBattleReward(_ reward: BattleReward) {
+        state.xp += reward.xpGained
+        state.totalXp += reward.xpGained
+        if let item = reward.droppedEquipment {
+            state.inventory.append(item)
+        }
+        save()
+    }
+}

--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -8,7 +8,7 @@ import DamagochiStorage
 import DamagochiRenderer
 
 enum AppTab: String, CaseIterable {
-    case pet, inventory, achievements, graveyard, notifications, settings
+    case pet, inventory, achievements, graveyard, notifications, battle, settings
 
     var icon: String {
         switch self {
@@ -17,6 +17,7 @@ enum AppTab: String, CaseIterable {
         case .achievements:  return "trophy.fill"
         case .graveyard:     return "book.closed.fill"
         case .notifications: return "bell.fill"
+        case .battle:        return "bolt.shield.fill"
         case .settings:      return "gearshape.fill"
         }
     }
@@ -629,7 +630,7 @@ final class PetViewModel: ObservableObject {
         NSApp.terminate(nil)
     }
 
-    private func save() {
+    func save() {
         store.save(state)
     }
 }

--- a/Sources/DamagochiApp/Views/BattleView.swift
+++ b/Sources/DamagochiApp/Views/BattleView.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+import DamagochiCore
+import DamagochiNetwork
+
+struct BattleView: View {
+    @ObservedObject var battleVM: BattleViewModel
+    @ObservedObject var petVM: PetViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("배틀")
+                .font(.headline)
+            Spacer()
+            if case .browsing = battleVM.phase {
+                HStack(spacing: 4) {
+                    ProgressView().scaleEffect(0.6)
+                    Text("탐색 중").font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Content Router
+
+    @ViewBuilder
+    private var content: some View {
+        switch battleVM.phase {
+        case .browsing, .connecting:
+            browsingView
+        case .inBattle:
+            if let state = battleVM.battleState {
+                battleView(state: state)
+            }
+        case .finished(let won):
+            resultView(won: won)
+        }
+    }
+
+    // MARK: - Browsing View
+
+    private var browsingView: some View {
+        VStack(spacing: 10) {
+            myStatsCard
+                .padding(.horizontal, 10)
+                .padding(.top, 8)
+
+            Divider().padding(.horizontal, 10)
+
+            if battleVM.foundPeers.isEmpty {
+                Spacer()
+                VStack(spacing: 8) {
+                    Text("👥").font(.system(size: 32))
+                    Text("같은 Wi-Fi의 상대를 찾는 중...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(spacing: 6) {
+                        ForEach(battleVM.foundPeers) { peer in
+                            peerRow(peer)
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                }
+            }
+
+            if let err = battleVM.errorMessage {
+                Text(err).font(.caption).foregroundStyle(.red).padding(.horizontal)
+            }
+        }
+    }
+
+    private var myStatsCard: some View {
+        guard let profile = BattleProfile.from(petVM.state) else {
+            return AnyView(Text("펫이 없습니다").font(.caption).foregroundStyle(.secondary))
+        }
+        return AnyView(
+            VStack(spacing: 4) {
+                HStack {
+                    Text(profile.petName).font(.subheadline.bold())
+                    rarityBadge(profile.speciesRarity)
+                    Spacer()
+                    Text("Lv.\(petVM.state.level)").font(.caption).foregroundStyle(.secondary)
+                }
+                statGrid(profile.stats)
+            }
+            .padding(8)
+            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8))
+        )
+    }
+
+    private func peerRow(_ peer: BattleViewModel.FoundPeer) -> some View {
+        let isConnecting: Bool
+        if case .connecting(let id) = battleVM.phase, id == peer.id {
+            isConnecting = true
+        } else {
+            isConnecting = false
+        }
+
+        return HStack {
+            Text("⚔️")
+            Text(peer.name).font(.subheadline)
+            Spacer()
+            if isConnecting {
+                ProgressView().scaleEffect(0.7)
+            } else {
+                Button("배틀") { battleVM.invitePeer(peer) }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+            }
+        }
+        .padding(8)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Battle View
+
+    private func battleView(state: BattleState) -> some View {
+        VStack(spacing: 0) {
+            // 상대방
+            combatantRow(
+                name: state.opponentProfile.petName,
+                rarity: state.opponentProfile.speciesRarity,
+                currentHp: state.opponentProfile.stats.currentHp,
+                maxHp: state.opponentProfile.stats.maxHp,
+                isOpponent: true
+            )
+            .padding(.horizontal, 10)
+            .padding(.top, 6)
+
+            // 배틀 로그
+            battleLog(state.log)
+                .frame(height: 70)
+                .padding(.horizontal, 10)
+
+            // 나
+            combatantRow(
+                name: state.myProfile.petName,
+                rarity: state.myProfile.speciesRarity,
+                currentHp: state.myProfile.stats.currentHp,
+                maxHp: state.myProfile.stats.maxHp,
+                isOpponent: false
+            )
+            .padding(.horizontal, 10)
+
+            Divider().padding(.vertical, 4)
+
+            // 스킬 선택
+            skillGrid(state: state)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 6)
+
+            // 항복 버튼
+            Button("항복") { battleVM.forfeit() }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 4)
+        }
+    }
+
+    private func combatantRow(name: String, rarity: Rarity, currentHp: Int, maxHp: Int, isOpponent: Bool) -> some View {
+        VStack(spacing: 3) {
+            HStack {
+                if isOpponent { Text("👾") } else { Text("🐾") }
+                Text(name).font(.caption.bold())
+                rarityBadge(rarity)
+                Spacer()
+                Text("\(currentHp)/\(maxHp)").font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(.quaternary)
+                        .frame(height: 6)
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(hpColor(current: currentHp, max: maxHp))
+                        .frame(width: geo.size.width * CGFloat(currentHp) / CGFloat(max(1, maxHp)), height: 6)
+                        .animation(.easeInOut(duration: 0.3), value: currentHp)
+                }
+            }
+            .frame(height: 6)
+        }
+        .padding(6)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func battleLog(_ log: [String]) -> some View {
+        let startIndex = max(0, log.count - 8)
+        return ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(log.suffix(8).enumerated()), id: \.offset) { i, line in
+                        Text(line)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .id(startIndex + i)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(6)
+            }
+            .background(.quaternary.opacity(0.2), in: RoundedRectangle(cornerRadius: 6))
+            .onChange(of: log.count) { _, _ in
+                let lastId = log.count - 1
+                if lastId >= 0 { proxy.scrollTo(lastId, anchor: .bottom) }
+            }
+        }
+    }
+
+    private func skillGrid(state: BattleState) -> some View {
+        let skills = BattleSkill.skills(for: state.myProfile.mbtiGroup)
+        let isSelecting = battleVM.turnPhase == .selectingSkill
+
+        return VStack(spacing: 5) {
+            if battleVM.turnPhase == .waitingForOpponent {
+                HStack(spacing: 4) {
+                    ProgressView().scaleEffect(0.6)
+                    Text("상대방 선택 대기 중...").font(.caption).foregroundStyle(.secondary)
+                }
+                .frame(height: 20)
+            } else {
+                Text("턴 \(state.turn) — 스킬을 선택하세요").font(.caption2).foregroundStyle(.secondary)
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 5) {
+                ForEach(skills, id: \.id) { skill in
+                    skillButton(skill: skill, isSelecting: isSelecting)
+                }
+            }
+        }
+    }
+
+    private func skillButton(skill: BattleSkill, isSelecting: Bool) -> some View {
+        let isSelected = battleVM.selectedSkillId == skill.id
+        return Button(action: {
+            if isSelecting { battleVM.selectSkill(skill.id) }
+        }) {
+            HStack(spacing: 4) {
+                Text(skill.icon).font(.system(size: 14))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(skill.name).font(.caption.bold()).lineLimit(1)
+                    Text(skill.isAttack ? "공격" : "버프").font(.system(size: 8)).foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(
+                isSelected ? Color.blue.opacity(0.3) : Color.gray.opacity(0.15),
+                in: RoundedRectangle(cornerRadius: 6)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!isSelecting)
+        .opacity(isSelecting ? 1.0 : 0.5)
+    }
+
+    // MARK: - Result View
+
+    private func resultView(won: Bool) -> some View {
+        VStack(spacing: 12) {
+            Spacer()
+
+            Text(won ? "🏆 승리!" : "💀 패배")
+                .font(.title.bold())
+                .foregroundStyle(won ? .yellow : .secondary)
+
+            if let turns = battleVM.battleState?.turn {
+                Text("\(turns - 1)턴 만에 종료").font(.caption).foregroundStyle(.secondary)
+            }
+
+            if let reward = battleVM.lastReward {
+                VStack(spacing: 6) {
+                    HStack {
+                        Text("✨ XP +\(reward.xpGained)").font(.subheadline.bold())
+                    }
+                    if let item = reward.droppedEquipment {
+                        HStack(spacing: 4) {
+                            rarityBadge(item.rarity)
+                            Text("\(item.name) 획득!").font(.caption)
+                        }
+                        .padding(6)
+                        .background(.yellow.opacity(0.2), in: RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+                .padding()
+                .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
+            }
+
+            Spacer()
+
+            Button("돌아가기") { battleVM.reset() }
+                .buttonStyle(.borderedProminent)
+                .padding(.bottom)
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    private func statGrid(_ stats: BattleStats) -> some View {
+        HStack(spacing: 0) {
+            statItem(label: "ATK", value: stats.atk)
+            statItem(label: "INT", value: stats.int_)
+            statItem(label: "HP", value: stats.maxHp)
+            statItem(label: "SPD", value: stats.spd)
+            statItem(label: "DEF", value: stats.def)
+        }
+    }
+
+    private func statItem(label: String, value: Int) -> some View {
+        VStack(spacing: 1) {
+            Text(label).font(.system(size: 8)).foregroundStyle(.secondary)
+            Text("\(value)").font(.system(size: 10, design: .monospaced).bold())
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func rarityBadge(_ rarity: Rarity) -> some View {
+        Text(rarity.shortLabel)
+            .font(.system(size: 8).bold())
+            .foregroundStyle(rarity.color)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(rarity.color.opacity(0.15), in: Capsule())
+    }
+
+    private func hpColor(current: Int, max: Int) -> Color {
+        let ratio = Double(current) / Double(Swift.max(1, max))
+        if ratio > 0.5 { return .green }
+        if ratio > 0.25 { return .yellow }
+        return .red
+    }
+}
+
+// MARK: - Rarity Display
+
+extension Rarity {
+    var shortLabel: String {
+        switch self {
+        case .common:    return "C"
+        case .rare:      return "R"
+        case .legendary: return "L"
+        case .mythic:    return "M"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .common:    return .gray
+        case .rare:      return .blue
+        case .legendary: return .purple
+        case .mythic:    return .orange
+        }
+    }
+}

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -4,8 +4,14 @@ import DamagochiRenderer
 
 struct PopoverView: View {
     @ObservedObject var viewModel: PetViewModel
+    @StateObject private var battleVM: BattleViewModel
     @State private var showOnboarding = !UserDefaults.standard.bool(forKey: "onboardingCompleted")
     @State private var statsTooltip: String? = nil
+
+    init(viewModel: PetViewModel) {
+        self.viewModel = viewModel
+        self._battleVM = StateObject(wrappedValue: BattleViewModel(petViewModel: viewModel))
+    }
 
     var body: some View {
         Group {
@@ -41,6 +47,7 @@ struct PopoverView: View {
         case .achievements:  AchievementView(viewModel: viewModel)
         case .graveyard:     GraveyardView(viewModel: viewModel)
         case .notifications: NotificationsView(viewModel: viewModel)
+        case .battle:        BattleView(battleVM: battleVM, petVM: viewModel)
         case .settings:      SettingsView(viewModel: viewModel)
         }
     }

--- a/Sources/DamagochiCore/Battle/BattleEngine.swift
+++ b/Sources/DamagochiCore/Battle/BattleEngine.swift
@@ -1,0 +1,382 @@
+import Foundation
+
+// MARK: - Battle State
+
+public struct BattleState: Sendable {
+    public var myProfile: BattleProfile
+    public var opponentProfile: BattleProfile
+    public var turn: Int
+    public var log: [String]
+    public var status: BattleStatus
+
+    // 버프/디버프 (해당 턴에만 적용 후 소멸)
+    public var myBuffs: ActiveBuffs
+    public var opponentBuffs: ActiveBuffs
+
+    public init(me: BattleProfile, opponent: BattleProfile) {
+        self.myProfile = me
+        self.opponentProfile = opponent
+        self.turn = 1
+        self.log = []
+        self.status = .ongoing
+        self.myBuffs = ActiveBuffs()
+        self.opponentBuffs = ActiveBuffs()
+    }
+}
+
+public enum BattleStatus: Sendable, Equatable {
+    case ongoing
+    case victory
+    case defeat
+    case draw
+}
+
+public struct ActiveBuffs: Sendable {
+    public var defMultiplier: Double = 1.0      // 방어막/철벽
+    public var atkMultiplier: Double = 1.0      // 광전사/버프
+    public var intMultiplier: Double = 1.0      // 영감
+    public var reflectRatio: Double = 0.0       // 카운터/가시 반격
+    public var dodgeChance: Double = 0.0        // 회피/신비
+    public var debuffDefRatio: Double = 0.0     // 상대 DEF 감소
+    public var debuffAtkRatio: Double = 0.0     // 상대 ATK 감소
+    public var guaranteedFirst: Bool = false    // 기습 선공 보장
+    public var atkBuffRemaining: Int = 0        // 남은 ATK 버프 턴 수
+    public var intBuffRemaining: Int = 0        // 남은 INT 버프 턴 수
+
+    public init() {}
+
+    mutating func reset() {
+        defMultiplier = 1.0
+        if atkBuffRemaining <= 0 {
+            atkMultiplier = 1.0
+        }
+        if intBuffRemaining <= 0 {
+            intMultiplier = 1.0
+        }
+        reflectRatio = 0.0
+        dodgeChance = 0.0
+        debuffDefRatio = 0.0
+        debuffAtkRatio = 0.0
+        guaranteedFirst = false
+    }
+}
+
+// MARK: - Battle Result
+
+public struct BattleReward: Sendable {
+    public let xpGained: Int
+    public let droppedEquipment: Equipment?
+
+    public init(xpGained: Int, droppedEquipment: Equipment?) {
+        self.xpGained = xpGained
+        self.droppedEquipment = droppedEquipment
+    }
+}
+
+public struct BattleResult: Codable, Sendable {
+    public let winnerId: String
+    public let loserId: String
+    public let turns: Int
+    public let log: [String]
+
+    public init(winnerId: String, loserId: String, turns: Int, log: [String]) {
+        self.winnerId = winnerId
+        self.loserId = loserId
+        self.turns = turns
+        self.log = log
+    }
+}
+
+// MARK: - Battle Engine
+
+public struct BattleEngine: Sendable {
+
+    /// 한 턴 처리: 양쪽 스킬 선택 → SPD 순서로 실행 → 상태 반환
+    public static func resolveTurn(
+        state: inout BattleState,
+        mySkillId: String,
+        opponentSkillId: String
+    ) {
+        guard state.status == .ongoing else { return }
+
+        let mySkills = BattleSkill.skills(for: state.myProfile.mbtiGroup)
+        let opponentSkills = BattleSkill.skills(for: state.opponentProfile.mbtiGroup)
+
+        guard let mySkill = mySkills.first(where: { $0.id == mySkillId }),
+              let opponentSkill = opponentSkills.first(where: { $0.id == opponentSkillId })
+        else { return }
+
+        // spdAttack 스킬 사용 시 선공 보장 (determineFirst 호출 전에 설정)
+        if case .spdAttack = mySkill.effect {
+            state.myBuffs.guaranteedFirst = true
+        }
+        if case .spdAttack = opponentSkill.effect {
+            state.opponentBuffs.guaranteedFirst = true
+        }
+
+        // 선공 결정: 기습 보장 > SPD 비교 > 랜덤
+        let myGoesFirst = determineFirst(
+            mySpd: state.myProfile.stats.spd,
+            opponentSpd: state.opponentProfile.stats.spd,
+            myGuaranteed: state.myBuffs.guaranteedFirst,
+            opponentGuaranteed: state.opponentBuffs.guaranteedFirst
+        )
+
+        state.log.append("=== 턴 \(state.turn) ===")
+
+        if myGoesFirst {
+            applySkill(skill: mySkill, attacker: &state.myProfile, defender: &state.opponentProfile,
+                       attackerBuffs: &state.myBuffs, defenderBuffs: &state.opponentBuffs,
+                       attackerName: state.myProfile.petName, defenderName: state.opponentProfile.petName,
+                       log: &state.log)
+            if state.opponentProfile.stats.currentHp <= 0 {
+                state.status = .victory
+                state.turn += 1
+                return
+            }
+            applySkill(skill: opponentSkill, attacker: &state.opponentProfile, defender: &state.myProfile,
+                       attackerBuffs: &state.opponentBuffs, defenderBuffs: &state.myBuffs,
+                       attackerName: state.opponentProfile.petName, defenderName: state.myProfile.petName,
+                       log: &state.log)
+            if state.myProfile.stats.currentHp <= 0 { state.status = .defeat }
+        } else {
+            applySkill(skill: opponentSkill, attacker: &state.opponentProfile, defender: &state.myProfile,
+                       attackerBuffs: &state.opponentBuffs, defenderBuffs: &state.myBuffs,
+                       attackerName: state.opponentProfile.petName, defenderName: state.myProfile.petName,
+                       log: &state.log)
+            if state.myProfile.stats.currentHp <= 0 {
+                state.status = .defeat
+                state.turn += 1
+                return
+            }
+            applySkill(skill: mySkill, attacker: &state.myProfile, defender: &state.opponentProfile,
+                       attackerBuffs: &state.myBuffs, defenderBuffs: &state.opponentBuffs,
+                       attackerName: state.myProfile.petName, defenderName: state.opponentProfile.petName,
+                       log: &state.log)
+            if state.opponentProfile.stats.currentHp <= 0 { state.status = .victory }
+        }
+
+        // 턴 종료: 버프 소멸
+        state.myBuffs.reset()
+        state.opponentBuffs.reset()
+        state.turn += 1
+    }
+
+    // MARK: - 스킬 적용
+
+    private static func applySkill(
+        skill: BattleSkill,
+        attacker: inout BattleProfile,
+        defender: inout BattleProfile,
+        attackerBuffs: inout ActiveBuffs,
+        defenderBuffs: inout ActiveBuffs,
+        attackerName: String,
+        defenderName: String,
+        log: inout [String]
+    ) {
+        switch skill.effect {
+
+        case .physicalAttack(let mult):
+            let isCombo = skill.id == "sp_combo"
+            let isThorn = skill.id == "sj_thorn"
+            var atkStat = Double(attacker.stats.atk) * attackerBuffs.atkMultiplier
+            atkStat *= (1.0 - defenderBuffs.debuffAtkRatio)
+            let effectiveDef = Double(defender.stats.def) * defenderBuffs.defMultiplier * (1.0 - defenderBuffs.debuffDefRatio)
+
+            if isThorn {
+                // 가시 반격: 공격 + 이번 턴 받는 피해 30% 반사 등록
+                let dmg = calcDamage(attack: atkStat * mult, def: effectiveDef, dodgeChance: defenderBuffs.dodgeChance)
+                applyDamage(dmg, to: &defender, reflectTo: &attacker, reflectRatio: defenderBuffs.reflectRatio, log: &log, attackerName: attackerName, defenderName: defenderName, skillName: skill.name)
+                attackerBuffs.reflectRatio = 0.3
+                log.append("  \(attackerName)에게 가시 반격 발동! 다음 피해의 30% 반사")
+            } else if isCombo {
+                // 연속 공격: 2회 판정
+                for i in 1...2 {
+                    let dmg = calcDamage(attack: atkStat * mult, def: effectiveDef, dodgeChance: defenderBuffs.dodgeChance)
+                    applyDamage(dmg, to: &defender, reflectTo: &attacker, reflectRatio: defenderBuffs.reflectRatio, log: &log, attackerName: attackerName, defenderName: defenderName, skillName: "\(skill.name) \(i)타")
+                    if defender.stats.currentHp <= 0 { break }
+                }
+            } else {
+                let dmg = calcDamage(attack: atkStat * mult, def: effectiveDef, dodgeChance: defenderBuffs.dodgeChance)
+                applyDamage(dmg, to: &defender, reflectTo: &attacker, reflectRatio: defenderBuffs.reflectRatio, log: &log, attackerName: attackerName, defenderName: defenderName, skillName: skill.name)
+            }
+
+        case .magicAttack(let mult):
+            var intStat = Double(attacker.stats.int_) * attackerBuffs.intMultiplier
+            // 저주는 물리/마법 공격력 모두 감소 (공격력 전체 디버프)
+            intStat *= (1.0 - defenderBuffs.debuffAtkRatio)
+            let effectiveDef = Double(defender.stats.def) * defenderBuffs.defMultiplier * (1.0 - defenderBuffs.debuffDefRatio)
+            let dmg = calcDamage(attack: intStat * mult, def: effectiveDef, dodgeChance: defenderBuffs.dodgeChance)
+            applyDamage(dmg, to: &defender, reflectTo: &attacker, reflectRatio: defenderBuffs.reflectRatio, log: &log, attackerName: attackerName, defenderName: defenderName, skillName: skill.name)
+
+            // 분석타: 상대 DEF -20% 다음 턴
+            if skill.id == "nt_analyze" {
+                defenderBuffs.debuffDefRatio = 0.2
+                log.append("  \(defenderName)의 방어력 -20% (다음 턴)")
+            }
+
+            // 저주: 상대 ATK -25% 다음 턴
+            if skill.id == "nf_curse" {
+                defenderBuffs.debuffAtkRatio = 0.25
+                log.append("  \(defenderName)의 공격력 -25% (다음 턴)")
+            }
+
+        case .spdAttack(let mult):
+            // SPD 기반 공격, 선공은 이미 결정된 상태
+            let effectiveDef = Double(defender.stats.def) * defenderBuffs.defMultiplier * (1.0 - defenderBuffs.debuffDefRatio)
+            let dmg = calcDamage(attack: Double(attacker.stats.spd) * mult, def: effectiveDef, dodgeChance: defenderBuffs.dodgeChance)
+            applyDamage(dmg, to: &defender, reflectTo: &attacker, reflectRatio: defenderBuffs.reflectRatio, log: &log, attackerName: attackerName, defenderName: defenderName, skillName: skill.name)
+
+        case .reflectNext(let ratio):
+            attackerBuffs.reflectRatio = ratio
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) 발동 — 다음 피해의 \(Int(ratio*100))% 반사")
+
+        case .buffDef(let ratio):
+            attackerBuffs.defMultiplier = 1.0 + ratio
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) — 방어력 +\(Int(ratio*100))% (이번 턴)")
+
+        case .buffAtk(let ratio):
+            attackerBuffs.atkMultiplier = 1.0 + ratio
+            attackerBuffs.atkBuffRemaining = 2
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) — 공격력 +\(Int(ratio*100))% (다음 공격)")
+
+        case .buffInt(let ratio):
+            attackerBuffs.intMultiplier = 1.0 + ratio
+            attackerBuffs.intBuffRemaining = 2
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) — 마법 공격 +\(Int(ratio*100))% (다음 공격)")
+
+        case .heal(let ratio):
+            let healAmt = Int(Double(attacker.stats.maxHp) * ratio)
+            let newHp = min(attacker.stats.maxHp, attacker.stats.currentHp + healAmt)
+            attacker.stats.currentHp = newHp
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) — HP +\(healAmt) (\(newHp)/\(attacker.stats.maxHp))")
+
+        case .dodge(let chance):
+            attackerBuffs.dodgeChance = chance
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) — 다음 공격 \(Int(chance*100))% 회피 준비")
+
+        case .berserk(let threshold, let highRatio, let lowRatio):
+            let hpRatio = Double(attacker.stats.currentHp) / Double(attacker.stats.maxHp)
+            let ratio = hpRatio < threshold ? highRatio : lowRatio
+            attackerBuffs.atkMultiplier = 1.0 + ratio
+            attackerBuffs.atkBuffRemaining = 2
+            let label = hpRatio < threshold ? "광전사 발동!" : "준비 상태"
+            log.append("  \(attackerName) \(skill.icon)\(skill.name) \(label) — 공격력 +\(Int(ratio*100))%")
+        }
+
+        // 공격 스킬 사용 후 버프 카운터 감소
+        if skill.isAttack {
+            if attackerBuffs.atkBuffRemaining > 0 {
+                attackerBuffs.atkBuffRemaining -= 1
+                if attackerBuffs.atkBuffRemaining <= 0 {
+                    attackerBuffs.atkMultiplier = 1.0
+                }
+            }
+            if attackerBuffs.intBuffRemaining > 0 {
+                attackerBuffs.intBuffRemaining -= 1
+                if attackerBuffs.intBuffRemaining <= 0 {
+                    attackerBuffs.intMultiplier = 1.0
+                }
+            }
+        }
+    }
+
+    // MARK: - 피해 계산 (비율 기반 DEF)
+
+    private static func calcDamage(attack: Double, def: Double, dodgeChance: Double) -> Int {
+        // 회피 판정
+        if dodgeChance > 0 && Double.random(in: 0...1) < dodgeChance {
+            return -1   // -1 = 회피
+        }
+        // 실피해 = attack × (100 / (100 + DEF))
+        let reduction = 100.0 / (100.0 + def)
+        return max(1, Int(attack * reduction))
+    }
+
+    private static func applyDamage(
+        _ damage: Int,
+        to defender: inout BattleProfile,
+        reflectTo attacker: inout BattleProfile,
+        reflectRatio: Double,
+        log: inout [String],
+        attackerName: String,
+        defenderName: String,
+        skillName: String
+    ) {
+        if damage == -1 {
+            log.append("  \(attackerName) → \(defenderName) \(skillName): 회피!")
+            return
+        }
+        defender.stats.currentHp = max(0, defender.stats.currentHp - damage)
+        log.append("  \(attackerName) → \(defenderName) \(skillName): \(damage) 피해 (HP \(defender.stats.currentHp)/\(defender.stats.maxHp))")
+
+        // 반사 처리
+        if reflectRatio > 0 {
+            let reflected = max(1, Int(Double(damage) * reflectRatio))
+            attacker.stats.currentHp = max(0, attacker.stats.currentHp - reflected)
+            log.append("  \(defenderName) 반사: \(reflected) 피해 → \(attackerName) (HP \(attacker.stats.currentHp)/\(attacker.stats.maxHp))")
+        }
+    }
+
+    // MARK: - 선공 결정
+
+    private static func determineFirst(
+        mySpd: Int,
+        opponentSpd: Int,
+        myGuaranteed: Bool,
+        opponentGuaranteed: Bool
+    ) -> Bool {
+        if myGuaranteed && !opponentGuaranteed { return true }
+        if opponentGuaranteed && !myGuaranteed { return false }
+        if mySpd != opponentSpd { return mySpd > opponentSpd }
+        return Bool.random()
+    }
+
+    // MARK: - 배틀 보상 계산
+
+    public static func calcReward(
+        won: Bool,
+        myLevel: Int,
+        opponentRarity: Rarity,
+        allEquipment: [Equipment]
+    ) -> BattleReward {
+        let levelMult = 1.0 + Double(myLevel) * 0.1
+        let baseXp = won ? 50 : 10
+        let xp = Int(Double(baseXp) * levelMult)
+
+        let dropChance = won ? dropChance(for: opponentRarity) : 0.0
+        let dropped = Double.random(in: 0...1) < dropChance
+            ? randomEquipment(biasedTo: opponentRarity, from: allEquipment)
+            : nil
+
+        return BattleReward(xpGained: xp, droppedEquipment: dropped)
+    }
+
+    private static func dropChance(for rarity: Rarity) -> Double {
+        switch rarity {
+        case .common:    return 0.05
+        case .rare:      return 0.10
+        case .legendary: return 0.15
+        case .mythic:    return 0.25
+        }
+    }
+
+    private static func randomEquipment(biasedTo rarity: Rarity, from all: [Equipment]) -> Equipment? {
+        // 상대 레어도 이하 범위에서 랜덤 드롭
+        let eligible = all.filter { $0.rarity.dropWeight <= rarity.dropWeight }
+        return eligible.randomElement()
+    }
+}
+
+// MARK: - Rarity Drop Weight
+
+extension Rarity {
+    var dropWeight: Int {
+        switch self {
+        case .common:    return 1
+        case .rare:      return 2
+        case .legendary: return 3
+        case .mythic:    return 4
+        }
+    }
+}

--- a/Sources/DamagochiCore/Battle/BattleProfile.swift
+++ b/Sources/DamagochiCore/Battle/BattleProfile.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+// MARK: - Battle Stats
+
+public struct BattleStats: Codable, Sendable, Equatable {
+    public let atk: Int      // 물리 공격 (totalToolUses 기반)
+    public let int_: Int     // 마법 공격 (totalPrompts 기반)
+    public let maxHp: Int    // 최대 HP (totalSessions 기반)
+    public let spd: Int      // 스피드 (streakDays 기반)
+    public let def: Int      // 방어력 (장비 등급 기반)
+    public var currentHp: Int
+
+    public init(atk: Int, int_: Int, maxHp: Int, spd: Int, def: Int) {
+        self.atk = atk
+        self.int_ = int_
+        self.maxHp = maxHp
+        self.spd = spd
+        self.def = def
+        self.currentHp = maxHp
+    }
+}
+
+// MARK: - Battle Profile
+
+public struct BattleProfile: Codable, Sendable, Identifiable {
+    public let id: String
+    public let petName: String
+    public let speciesId: String
+    public let mbtiGroup: MbtiGroup
+    public let speciesRarity: Rarity
+    public var stats: BattleStats
+
+    public init(
+        id: String,
+        petName: String,
+        speciesId: String,
+        mbtiGroup: MbtiGroup,
+        speciesRarity: Rarity,
+        stats: BattleStats
+    ) {
+        self.id = id
+        self.petName = petName
+        self.speciesId = speciesId
+        self.mbtiGroup = mbtiGroup
+        self.speciesRarity = speciesRarity
+        self.stats = stats
+    }
+}
+
+// MARK: - PetState → BattleProfile
+
+public extension BattleProfile {
+    static func from(_ state: PetState) -> BattleProfile? {
+        guard state.phase == .alive,
+              let speciesId = state.species,
+              let species = Species.allSpecies.first(where: { $0.id == speciesId })
+        else { return nil }
+
+        let levelMult  = 1.0 + Double(state.level) * 0.1
+        let rarityMult = species.rarity.battleMultiplier
+
+        let handBonus = handAtkBonus(equipped: state.equippedItems, inventory: state.inventory)
+        let atk  = max(1, Int(log(Double(state.totalToolUses + 1)) * 10.0 * levelMult * rarityMult)) + handBonus
+        let int_ = max(1, Int(log(Double(state.totalPrompts  + 1)) * 10.0 * levelMult * rarityMult))
+        let hp   = max(100, Int(log(Double(state.totalSessions + 1)) * 150.0 * levelMult * rarityMult))
+        let spd  = max(1, Int(Double(state.streakDays) * 5.0 * levelMult * rarityMult))
+        let def  = calcDef(equipped: state.equippedItems, inventory: state.inventory)
+
+        let stats = BattleStats(atk: atk, int_: int_, maxHp: hp, spd: spd, def: def)
+        return BattleProfile(
+            id: state.machineId,
+            petName: state.name ?? species.name,
+            speciesId: speciesId,
+            mbtiGroup: species.group,
+            speciesRarity: species.rarity,
+            stats: stats
+        )
+    }
+
+    // HEAD → DEF, HAND → ATK 보너스, EFFECT → DEF
+    private static func calcDef(equipped: EquippedItems, inventory: [Equipment]) -> Int {
+        var def = 0
+        if let id = equipped.head, let item = inventory.first(where: { $0.id == id }) {
+            def += item.rarity.headDef
+        }
+        if let id = equipped.effect, let item = inventory.first(where: { $0.id == id }) {
+            def += item.rarity.effectDef
+        }
+        return def
+    }
+
+    // HAND 장비 ATK 보너스 (BattleEngine에서 사용)
+    static func handAtkBonus(equipped: EquippedItems, inventory: [Equipment]) -> Int {
+        guard let id = equipped.hand,
+              let item = inventory.first(where: { $0.id == id })
+        else { return 0 }
+        return item.rarity.handAtkBonus
+    }
+}
+
+// MARK: - Rarity 배틀 수치
+
+extension Rarity {
+    public var battleMultiplier: Double {
+        switch self {
+        case .common:    return 1.0
+        case .rare:      return 1.1
+        case .legendary: return 1.25
+        case .mythic:    return 1.5
+        }
+    }
+
+    var headDef: Int {
+        switch self {
+        case .common:    return 5
+        case .rare:      return 15
+        case .legendary: return 30
+        case .mythic:    return 50
+        }
+    }
+
+    var effectDef: Int {
+        switch self {
+        case .common:    return 3
+        case .rare:      return 10
+        case .legendary: return 20
+        case .mythic:    return 35
+        }
+    }
+
+    var handAtkBonus: Int {
+        switch self {
+        case .common:    return 5
+        case .rare:      return 15
+        case .legendary: return 30
+        case .mythic:    return 50
+        }
+    }
+}

--- a/Sources/DamagochiCore/Battle/BattleSkill.swift
+++ b/Sources/DamagochiCore/Battle/BattleSkill.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+// MARK: - Skill Effect
+
+public enum SkillEffect: Codable, Sendable {
+    /// 일반 물리 공격 (ATK 기반)
+    case physicalAttack(multiplier: Double)
+    /// 마법 공격 (INT 기반)
+    case magicAttack(multiplier: Double)
+    /// SPD 기반 공격 + 선공 보장
+    case spdAttack(multiplier: Double)
+    /// 다음 받는 피해 반사 (비율)
+    case reflectNext(ratio: Double)
+    /// DEF 증폭 (이번 턴)
+    case buffDef(ratio: Double)
+    /// ATK 증폭 (다음 공격 1회)
+    case buffAtk(ratio: Double)
+    /// INT 증폭 (다음 공격 1회)
+    case buffInt(ratio: Double)
+    /// HP 회복 (maxHp 비율)
+    case heal(ratio: Double)
+    /// 회피 (다음 받는 공격)
+    case dodge(chance: Double)
+    /// 조건부 ATK 증폭 (HP < threshold 이면 highRatio, 아니면 lowRatio)
+    case berserk(threshold: Double, highRatio: Double, lowRatio: Double)
+}
+
+// MARK: - Skill Definition
+
+public struct BattleSkill: Sendable {
+    public let id: String
+    public let name: String
+    public let icon: String
+    public let effect: SkillEffect
+    public let isAttack: Bool
+
+    public init(id: String, name: String, icon: String, effect: SkillEffect, isAttack: Bool) {
+        self.id = id
+        self.name = name
+        self.icon = icon
+        self.effect = effect
+        self.isAttack = isAttack
+    }
+}
+
+// MARK: - Skills per MBTI Group
+
+public extension BattleSkill {
+
+    // MARK: NT (분석형) — 공격 2 + 유틸 2
+    static let ntSkills: [BattleSkill] = [
+        BattleSkill(
+            id: "nt_overclock",
+            name: "오버클락",
+            icon: "⚡",
+            effect: .physicalAttack(multiplier: 1.3),
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "nt_analyze",
+            name: "분석타",
+            icon: "🔍",
+            effect: .magicAttack(multiplier: 1.2),   // 피해 + 상대 DEF -20% 효과는 BattleEngine에서 처리
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "nt_counter",
+            name: "카운터",
+            icon: "🛡️",
+            effect: .reflectNext(ratio: 0.5),
+            isAttack: false
+        ),
+        BattleSkill(
+            id: "nt_barrier",
+            name: "방어막",
+            icon: "🔒",
+            effect: .buffDef(ratio: 0.4),
+            isAttack: false
+        ),
+    ]
+
+    // MARK: NF (창의형) — 공격 2 + 유틸 2
+    static let nfSkills: [BattleSkill] = [
+        BattleSkill(
+            id: "nf_starburst",
+            name: "별빛 폭발",
+            icon: "✨",
+            effect: .magicAttack(multiplier: 1.4),
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "nf_curse",
+            name: "저주",
+            icon: "💫",
+            effect: .magicAttack(multiplier: 1.0),   // 피해 + 상대 ATK -25% 효과는 BattleEngine에서 처리
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "nf_inspire",
+            name: "영감",
+            icon: "🌟",
+            effect: .buffInt(ratio: 0.4),
+            isAttack: false
+        ),
+        BattleSkill(
+            id: "nf_mystic",
+            name: "신비",
+            icon: "🌀",
+            effect: .dodge(chance: 0.45),
+            isAttack: false
+        ),
+    ]
+
+    // MARK: SJ (안정형) — 공격 2 + 유틸 2
+    static let sjSkills: [BattleSkill] = [
+        BattleSkill(
+            id: "sj_smash",
+            name: "강타",
+            icon: "💪",
+            effect: .physicalAttack(multiplier: 1.4),
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "sj_thorn",
+            name: "가시 반격",
+            icon: "🌵",
+            effect: .physicalAttack(multiplier: 1.0),  // 피해 + 이번 턴 받는 피해 30% 반사
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "sj_ironwall",
+            name: "철벽",
+            icon: "🧱",
+            effect: .buffDef(ratio: 0.6),
+            isAttack: false
+        ),
+        BattleSkill(
+            id: "sj_heal",
+            name: "회복",
+            icon: "💚",
+            effect: .heal(ratio: 0.2),
+            isAttack: false
+        ),
+    ]
+
+    // MARK: SP (자유형) — 공격 2 + 유틸 2
+    static let spSkills: [BattleSkill] = [
+        BattleSkill(
+            id: "sp_ambush",
+            name: "기습",
+            icon: "💨",
+            effect: .spdAttack(multiplier: 2.0),   // SPD 기반 + 이번 턴 선공 보장
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "sp_combo",
+            name: "연속 공격",
+            icon: "⚔️",
+            effect: .physicalAttack(multiplier: 1.2),  // 2회 판정은 BattleEngine에서 처리
+            isAttack: true
+        ),
+        BattleSkill(
+            id: "sp_dodge",
+            name: "회피",
+            icon: "🌪️",
+            effect: .dodge(chance: 0.5),
+            isAttack: false
+        ),
+        BattleSkill(
+            id: "sp_berserk",
+            name: "광전사",
+            icon: "🔥",
+            effect: .berserk(threshold: 0.5, highRatio: 0.6, lowRatio: 0.2),
+            isAttack: false
+        ),
+    ]
+
+    static func skills(for group: MbtiGroup) -> [BattleSkill] {
+        switch group {
+        case .nt: return ntSkills
+        case .nf: return nfSkills
+        case .sj: return sjSkills
+        case .sp: return spSkills
+        }
+    }
+}

--- a/Sources/DamagochiCore/Battle/BattleTransport.swift
+++ b/Sources/DamagochiCore/Battle/BattleTransport.swift
@@ -1,0 +1,75 @@
+import Foundation
+import CryptoKit
+
+// MARK: - Network Messages
+
+public enum BattleMessage: Codable, Sendable {
+    /// 연결 후 첫 핸드셰이크: 내 배틀 프로필 전송
+    case profile(BattleProfile)
+    /// 매 턴 스킬 선택 커밋 (commit-reveal: 해시 먼저)
+    case skillCommit(hash: String, turn: Int)
+    /// 커밋 확인 후 스킬 공개
+    case skillReveal(skillId: String, nonce: String, turn: Int)
+    /// 배틀 종료 확인
+    case battleEnd(result: BattleResult)
+    /// 항복
+    case forfeit
+}
+
+// MARK: - Transport Events
+
+public enum BattleTransportEvent: Sendable {
+    case peerFound(peerId: String, peerName: String)
+    case peerLost(peerId: String)
+    case connected(peerId: String)
+    case disconnected(peerId: String)
+    case messageReceived(BattleMessage)
+    case error(Error)
+}
+
+// MARK: - Transport Protocol
+
+/// 배틀 통신 레이어 추상화.
+/// Phase 1: LocalNetworkTransport (MultipeerConnectivity)
+/// Phase 2: SupabaseTransport (클라우드)
+public protocol BattleTransport: AnyObject, Sendable {
+    /// 상대 탐색 시작
+    func startBrowsing()
+    /// 탐색 중지
+    func stopBrowsing()
+    /// 특정 피어에 연결 요청
+    func connect(to peerId: String) async throws
+    /// 연결 해제
+    func disconnect()
+    /// 메시지 전송
+    func send(_ message: BattleMessage) throws
+    /// 이벤트 스트림 (AsyncStream)
+    var events: AsyncStream<BattleTransportEvent> { get }
+}
+
+// MARK: - Commit-Reveal Helper
+
+public enum CommitReveal {
+    /// 스킬 ID + 랜덤 nonce → SHA256 해시 (치팅 방지)
+    public static func commit(skillId: String, nonce: String) -> String {
+        let input = "\(skillId):\(nonce)"
+        let hash = SHA256.hash(data: Data(input.utf8))
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func makeNonce() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+}
+
+// MARK: - Turn Timeout
+
+public enum BattleTimeout {
+    /// 스킬 선택 제한 시간 (초)
+    public static let skillSelectSeconds: TimeInterval = 30
+    /// 타임아웃 시 자동 선택: 첫 번째 공격 스킬
+    public static func defaultSkillId(for group: MbtiGroup) -> String {
+        BattleSkill.skills(for: group).first(where: { $0.isAttack })?.id
+            ?? BattleSkill.skills(for: group)[0].id
+    }
+}

--- a/Sources/DamagochiCore/Engine/EquipmentDropper.swift
+++ b/Sources/DamagochiCore/Engine/EquipmentDropper.swift
@@ -38,7 +38,7 @@ public struct EquipmentDropper: Sendable {
         )
     }
 
-    static let itemPool: [Equipment] = [
+    public static let itemPool: [Equipment] = [
         // Head - Common
         Equipment(id: "head_common_1", name: "코딩 모자", slot: .head, rarity: .common, description: "평범한 코딩 모자"),
         Equipment(id: "head_common_2", name: "야구 모자", slot: .head, rarity: .common, description: "편안한 야구 모자"),

--- a/Sources/DamagochiNetwork/LocalNetworkTransport.swift
+++ b/Sources/DamagochiNetwork/LocalNetworkTransport.swift
@@ -1,0 +1,185 @@
+import Foundation
+import MultipeerConnectivity
+import DamagochiCore
+
+// MARK: - Local Network Transport (Phase 1)
+
+/// MultipeerConnectivity 기반 로컬 네트워크 배틀 통신
+public final class LocalNetworkTransport: NSObject, BattleTransport, @unchecked Sendable {
+
+    private static let serviceType = "damagochi-btl"
+
+    private let myPeerId: MCPeerID
+    private let session: MCSession
+    private let advertiser: MCNearbyServiceAdvertiser
+    private let browser: MCNearbyServiceBrowser
+
+    private var continuation: AsyncStream<BattleTransportEvent>.Continuation?
+    private let lock = NSLock()
+    private var _connectedPeerId: MCPeerID?
+    private var connectedPeerId: MCPeerID? {
+        get { lock.withLock { _connectedPeerId } }
+        set { lock.withLock { _connectedPeerId = newValue } }
+    }
+
+    public let events: AsyncStream<BattleTransportEvent>
+
+    public init(displayName: String) {
+        self.myPeerId = MCPeerID(displayName: displayName)
+        self.session = MCSession(peer: myPeerId, securityIdentity: nil, encryptionPreference: .required)
+        self.advertiser = MCNearbyServiceAdvertiser(peer: myPeerId, discoveryInfo: nil, serviceType: Self.serviceType)
+        self.browser = MCNearbyServiceBrowser(peer: myPeerId, serviceType: Self.serviceType)
+
+        var cont: AsyncStream<BattleTransportEvent>.Continuation?
+        self.events = AsyncStream { cont = $0 }
+        self.continuation = cont
+
+        super.init()
+
+        session.delegate = self
+        advertiser.delegate = self
+        browser.delegate = self
+    }
+
+    deinit {
+        advertiser.stopAdvertisingPeer()
+        browser.stopBrowsingForPeers()
+        session.disconnect()
+        continuation?.finish()
+    }
+
+    // MARK: - BattleTransport
+
+    public func startBrowsing() {
+        advertiser.startAdvertisingPeer()
+        browser.startBrowsingForPeers()
+    }
+
+    public func stopBrowsing() {
+        advertiser.stopAdvertisingPeer()
+        browser.stopBrowsingForPeers()
+    }
+
+    public func invite(_ peerId: String) throws {
+        guard let peer = session.connectedPeers.first(where: { $0.displayName == peerId })
+                      ?? findDiscoveredPeer(named: peerId)
+        else { throw TransportError.peerNotFound }
+        browser.invitePeer(peer, to: session, withContext: nil, timeout: 30)
+    }
+
+    public func connect(to peerId: String) async throws {
+        try invite(peerId)
+    }
+
+    public func disconnect() {
+        session.disconnect()
+        lock.withLock { _connectedPeerId = nil }
+    }
+
+    public func send(_ message: BattleMessage) throws {
+        guard let peer = lock.withLock({ _connectedPeerId }) else { throw TransportError.notConnected }
+        let data = try JSONEncoder().encode(message)
+        try session.send(data, toPeers: [peer], with: .reliable)
+    }
+
+    // MARK: - Private
+
+    private var _discoveredPeers: [MCPeerID] = []
+    private var discoveredPeers: [MCPeerID] {
+        get { lock.withLock { _discoveredPeers } }
+        set { lock.withLock { _discoveredPeers = newValue } }
+    }
+
+    private func findDiscoveredPeer(named name: String) -> MCPeerID? {
+        lock.withLock { _discoveredPeers.first { $0.displayName == name } }
+    }
+
+    private func emit(_ event: BattleTransportEvent) {
+        continuation?.yield(event)
+    }
+}
+
+// MARK: - MCSessionDelegate
+
+extension LocalNetworkTransport: MCSessionDelegate {
+
+    public func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        switch state {
+        case .connected:
+            lock.withLock { _connectedPeerId = peerID }
+            emit(.connected(peerId: peerID.displayName))
+        case .notConnected:
+            lock.withLock { if _connectedPeerId == peerID { _connectedPeerId = nil } }
+            emit(.disconnected(peerId: peerID.displayName))
+        default:
+            break
+        }
+    }
+
+    public func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        guard let message = try? JSONDecoder().decode(BattleMessage.self, from: data) else { return }
+        emit(.messageReceived(message))
+    }
+
+    public func session(_ session: MCSession, didReceive stream: InputStream,
+                        withName streamName: String, fromPeer peerID: MCPeerID) {}
+    public func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String,
+                        fromPeer peerID: MCPeerID, with progress: Progress) {}
+    public func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String,
+                        fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
+}
+
+// MARK: - MCNearbyServiceAdvertiserDelegate
+
+extension LocalNetworkTransport: MCNearbyServiceAdvertiserDelegate {
+
+    public func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                           didReceiveInvitationFromPeer peerID: MCPeerID,
+                           withContext context: Data?,
+                           invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        // 자동 수락 (UI에서 거절하려면 delegate 패턴 추가 가능)
+        invitationHandler(true, session)
+    }
+
+    public func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {
+        emit(.error(error))
+    }
+}
+
+// MARK: - MCNearbyServiceBrowserDelegate
+
+extension LocalNetworkTransport: MCNearbyServiceBrowserDelegate {
+
+    public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID,
+                        withDiscoveryInfo info: [String: String]?) {
+        lock.withLock {
+            if !_discoveredPeers.contains(where: { $0 == peerID }) {
+                _discoveredPeers.append(peerID)
+            }
+        }
+        emit(.peerFound(peerId: peerID.displayName, peerName: peerID.displayName))
+    }
+
+    public func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        lock.withLock { _discoveredPeers.removeAll { $0 == peerID } }
+        emit(.peerLost(peerId: peerID.displayName))
+    }
+
+    public func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
+        emit(.error(error))
+    }
+}
+
+// MARK: - Errors
+
+public enum TransportError: LocalizedError {
+    case peerNotFound
+    case notConnected
+
+    public var errorDescription: String? {
+        switch self {
+        case .peerNotFound:  return "상대방을 찾을 수 없습니다"
+        case .notConnected:  return "연결되지 않은 상태입니다"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- MBTI 그룹별 4스킬(공격2+유틸2) 턴제 배틀 시스템 추가
- MultipeerConnectivity(Bonjour) 기반 로컬 네트워크 대전
- 승리 시 XP 보상 + 확률 장비 드롭, BattleTransport 프로토콜로 Phase 2(클라우드) 전환 대비

## 주요 변경
### 배틀 코어 (DamagochiCore/Battle/)
- **BattleProfile**: PetState → 배틀 스탯 변환 (ATK/INT/HP/SPD/DEF)
  - ATK: totalToolUses, INT: totalPrompts, HP: totalSessions, SPD: streakDays 기반
  - DEF: HEAD+EFFECT 장비 등급, ATK 보너스: HAND 장비 등급
  - 비율 기반 DEF 공식: `실피해 = 공격 × (100 / (100 + DEF))`
- **BattleSkill**: NT/NF/SJ/SP 그룹별 4스킬 정의
- **BattleEngine**: 턴제 배틀 로직, 버프/디버프 카운터, 보상 계산
- **BattleTransport**: 프로토콜 추상화 + Commit-Reveal(SHA256) 치팅 방지

### 네트워크 (DamagochiNetwork/)
- **LocalNetworkTransport**: MultipeerConnectivity, NSLock 스레드 안전성

### UI (DamagochiApp/)
- **BattleView**: 탐색 → 배틀 → 결과 3단계 UI
- **BattleViewModel**: Commit-Reveal 프로토콜, 타임아웃(30초) 처리
- **AppTab**: 배틀 탭 추가

### 기타
- Info.plist: NSLocalNetworkUsageDescription, NSBonjourServices 추가
- EquipmentDropper.itemPool public 변경

## 배틀 흐름
```
1. 양쪽 스킬 선택 (동시, commit-reveal)
2. SPD 비교 → 높은 쪽 선공 (기습: 선공 보장)
3. 턴 진행 → HP ≤ 0 시 종료
4. 보상: 승리 XP 50×levelMult + 확률 장비 드롭
```

## Test plan
- [ ] Release 빌드 확인
- [ ] 같은 Wi-Fi에서 두 대의 Mac으로 배틀 테스트
- [ ] SPD 기반 선공 및 기습 선공 보장 확인
- [ ] 승리/패배 시 XP 보상 적용 확인
- [ ] 장비 드롭 확인
- [ ] 타임아웃 시 기본 스킬 자동 선택 확인
- [ ] 항복/연결 끊김 시 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)