### PR TITLE
feat: 앱 실행 시 일반 윈도우 표시 (메뉴바 가림 문제 우회)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -14,8 +14,6 @@
 	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>2.2.0</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_damagochi-btl._tcp</string>

--- a/Sources/DamagochiApp/AppDelegate.swift
+++ b/Sources/DamagochiApp/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var stateSubscription: AnyCancellable?
     private var walkSubscription: AnyCancellable?
     private var walkingWindowController: WalkingWindowController?
+    private var mainWindowController: MainWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NotificationManager.shared.requestPermission()
@@ -52,6 +53,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.walkingWindowController?.hide()
                 }
             }
+
+        mainWindowController = MainWindowController(viewModel: viewModel)
+        mainWindowController?.show()
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            mainWindowController?.show()
+        }
+        return true
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/DamagochiApp/Views/MainWindowController.swift
+++ b/Sources/DamagochiApp/Views/MainWindowController.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MainWindowController: NSObject, NSWindowDelegate {
+    private var window: NSWindow?
+    private let viewModel: PetViewModel
+
+    init(viewModel: PetViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func show() {
+        if let window = window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hostingController = NSHostingController(rootView: PopoverView(viewModel: viewModel))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 280, height: 420),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Damagochi"
+        window.contentViewController = hostingController
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.center()
+        window.setFrameAutosaveName("DamagochiMainWindow")
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window = window
+    }
+
+    func toggle() {
+        if let window = window, window.isVisible {
+            window.orderOut(nil)
+        } else {
+            show()
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        // Keep the window object so re-opening preserves state and frame.
+    }
+}


### PR DESCRIPTION
작은 맥북 화면에서 노치/메뉴바 오버플로우로 status item이 가려져
앱에 접근할 수 없는 문제를 해결합니다. 메뉴바 아이콘은 그대로
유지하면서 Dock 아이콘과 일반 윈도우를 함께 제공합니다.

- Info.plist: LSUIElement 제거 → Dock/Cmd+Tab에 표시
- MainWindowController: PopoverView를 호스팅하는 일반 NSWindow
- AppDelegate: 런치 시 윈도우 표시 + Dock 재실행 시 다시 띄우기