### PR TITLE
feat: 알림 전체 읽음 기능 및 빨간 뱃지 미읽음 기준으로 변경

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -237,6 +237,16 @@ final class PetViewModel: ObservableObject {
         }
     }
 
+    func markAllWalkNotificationsAsRead() {
+        for idx in walkNotifications.indices where !walkNotifications[idx].isRead {
+            walkNotifications[idx].isRead = true
+        }
+    }
+
+    var unreadWalkNotificationCount: Int {
+        walkNotifications.lazy.filter { !$0.isRead }.count
+    }
+
     private func applyWalkingDecay() {
         guard state.phase == .alive else { return }
         let oldHp = state.hp

--- a/Sources/DamagochiApp/Views/NotificationsView.swift
+++ b/Sources/DamagochiApp/Views/NotificationsView.swift
@@ -5,10 +5,18 @@ struct NotificationsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
+            HStack(spacing: 10) {
                 Text("알림")
                     .font(.headline)
                 Spacer()
+                if viewModel.unreadWalkNotificationCount > 0 {
+                    Button("전체 읽음") {
+                        viewModel.markAllWalkNotificationsAsRead()
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.blue)
+                    .buttonStyle(.plain)
+                }
                 if !viewModel.walkNotifications.isEmpty {
                     Button("전체 삭제") {
                         viewModel.walkNotifications.removeAll()

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -356,7 +356,7 @@ struct PopoverView: View {
                             .frame(maxWidth: .infinity, minHeight: 32)
                             .foregroundStyle(viewModel.selectedTab == tab ? .blue : .secondary)
 
-                        if tab == .notifications && !viewModel.walkNotifications.isEmpty {
+                        if tab == .notifications && viewModel.unreadWalkNotificationCount > 0 {
                             Circle()
                                 .fill(.red)
                                 .frame(width: 7, height: 7)


### PR DESCRIPTION
- 알림 헤더에 "전체 읽음" 버튼 추가 (미읽음 알림이 있을 때만 표시)
- 탭바의 빨간 뱃지가 전체 알림 개수가 아닌 미읽음 개수 기준으로 표시되도록 수정
- PetViewModel에 markAllWalkNotificationsAsRead() 및 unreadWalkNotificationCount 추가