### PR TITLE
fix: 산책 중 작업 완료/선택 대기 말풍선이 안 뜨던 문제 수정

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -124,6 +124,11 @@ final class PetViewModel: ObservableObject {
             .map { $0.prefix(8).map { String(format: "%02x", $0) }.joined() }
             ?? "unknown"
         self.state = store.load() ?? PetState(machineId: hostHash)
+        // Auto-upgrade older damagochi hook installs so newly added Stop/Notification hooks land
+        // without forcing the user to manually re-install.
+        if !hookInstaller.isInstalled() && hookInstaller.hasAnyDamagochiHook() {
+            try? hookInstaller.install()
+        }
         self.hookInstalled = hookInstaller.isInstalled()
     }
 
@@ -415,6 +420,17 @@ final class PetViewModel: ObservableObject {
     // MARK: - Private
 
     private func handleEvent(_ event: BehaviorEvent) {
+        if event.kind == .stop {
+            if isWalking { showWalkSpeechBubble("작업 완료! 수고했어요 🎉") }
+            return
+        }
+        if event.kind == .notification {
+            if isWalking {
+                let detail = event.metadata?["message"].map { ": \($0)" } ?? ""
+                showWalkSpeechBubble("선택이 필요해요\(detail) 👀")
+            }
+            return
+        }
         let oldLevel = state.level
         let oldPhase = state.phase
         let result = processor.process(event: event, state: &state)

--- a/Sources/DamagochiCLI/FeedCommand.swift
+++ b/Sources/DamagochiCLI/FeedCommand.swift
@@ -16,7 +16,7 @@ struct Feed: ParsableCommand {
         abstract: "Feed an event to the Damagochi pet"
     )
 
-    @Argument(help: "Event type: prompt, tool, session")
+    @Argument(help: "Event type: prompt, tool, session, stop, notification")
     var eventType: String
 
     func run() throws {
@@ -56,8 +56,20 @@ struct Feed: ParsableCommand {
             }
             UserDefaults.standard.set(now, forKey: key)
 
+        case "stop":
+            kind = .stop
+
+        case "notification":
+            kind = .notification
+            // Claude Code의 Notification hook은 stdin으로 message를 포함한 JSON을 보냄
+            if let data = readStdin(),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let message = json["message"] as? String {
+                metadata["message"] = message
+            }
+
         default:
-            throw ValidationError("Unknown event type: \(eventType). Use: prompt, tool, session")
+            throw ValidationError("Unknown event type: \(eventType). Use: prompt, tool, session, stop, notification")
         }
 
         let event = BehaviorEvent(kind: kind, metadata: metadata.isEmpty ? nil : metadata)

--- a/Sources/DamagochiCore/Engine/PersonalityTracker.swift
+++ b/Sources/DamagochiCore/Engine/PersonalityTracker.swift
@@ -25,6 +25,8 @@ public struct PersonalityTracker: Sendable {
             if let hour = event.metadata?["hour"], let h = Int(hour) {
                 scores.judging += (h >= 9 && h < 18) ? 1 : -1
             }
+        case .stop, .notification:
+            break
         }
     }
 

--- a/Sources/DamagochiCore/Engine/XPEngine.swift
+++ b/Sources/DamagochiCore/Engine/XPEngine.swift
@@ -8,6 +8,7 @@ public struct XPEngine: Sendable {
         case .prompt: return 5
         case .toolUse: return 3
         case .sessionStart: return 10
+        case .stop, .notification: return 0
         }
     }
 

--- a/Sources/DamagochiCore/Events/BehaviorEvent.swift
+++ b/Sources/DamagochiCore/Events/BehaviorEvent.swift
@@ -4,6 +4,8 @@ public enum EventKind: String, Codable, Sendable {
     case prompt
     case toolUse
     case sessionStart
+    case stop
+    case notification
 }
 
 public struct BehaviorEvent: Codable, Sendable {

--- a/Sources/DamagochiCore/Events/FeedProcessor.swift
+++ b/Sources/DamagochiCore/Events/FeedProcessor.swift
@@ -60,6 +60,9 @@ public struct FeedProcessor: Sendable {
 
     @discardableResult
     public func process(event: BehaviorEvent, state: inout PetState) -> FeedResult {
+        if case .stop = event.kind { return FeedResult() }
+        if case .notification = event.kind { return FeedResult() }
+
         var streakUpdated = false
         var newStreakDays = 0
         if case .sessionStart = event.kind {
@@ -82,6 +85,7 @@ public struct FeedProcessor: Sendable {
         case .prompt: state.totalPrompts += 1
         case .toolUse: state.totalToolUses += 1
         case .sessionStart: state.totalSessions += 1
+        case .stop, .notification: break
         }
 
         personalityTracker.updateMbti(scores: &state.mbtiScores, event: event)

--- a/Sources/DamagochiMonitor/HookInstaller.swift
+++ b/Sources/DamagochiMonitor/HookInstaller.swift
@@ -24,6 +24,8 @@ public struct HookInstaller: Sendable {
             "UserPromptSubmit": [HookEntry(command: "damagochi feed prompt")],
             "PostToolUse": [HookEntry(command: "damagochi feed tool")],
             "SessionStart": [HookEntry(command: "damagochi feed session")],
+            "Stop": [HookEntry(command: "damagochi feed stop")],
+            "Notification": [HookEntry(command: "damagochi feed notification")],
         ]
     }
 
@@ -100,6 +102,21 @@ public struct HookInstaller: Sendable {
             if !hasDamagochi { return false }
         }
         return true
+    }
+
+    public func hasAnyDamagochiHook() -> Bool {
+        guard let settings = try? loadSettings(),
+              let hooks = settings["hooks"] as? [String: Any] else { return false }
+        for (_, value) in hooks {
+            guard let entries = value as? [[String: Any]] else { continue }
+            for entry in entries {
+                guard let hooksList = entry["hooks"] as? [[String: Any]] else { continue }
+                if hooksList.contains(where: { ($0["command"] as? String)?.contains(Self.hookMarker) == true }) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private func loadSettings() throws -> [String: Any] {


### PR DESCRIPTION
기존 트리거(`onSessionEnd`)는 `~/.claude/.session-stats.json` 변경을
감시했지만 그 파일에 쓰는 코드가 어디에도 없어 한 번도 발화되지 않았음.
"선택사항이 있을 때" 알림은 아예 구현되지 않은 상태였음.

실제로 작동하는 EventBridge 경로에 트리거를 다시 연결:

- Claude Code의 Stop / Notification 훅을 기본 설치 목록에 추가
- `damagochi feed stop` / `damagochi feed notification` 서브커맨드 추가
- `EventKind`에 `.stop`, `.notification` 추가 (XP·상태 변경 없음)
- `PetViewModel.handleEvent`에서 산책 중일 때만 말풍선 표시
  - Stop  → "작업 완료! 수고했어요 🎉"
  - Notification → "선택이 필요해요(: <메시지>) 👀"
- 기존 사용자가 수동 재설치 없이 새 훅을 받도록, 부분 설치가
  감지되면 시작 시 한 번 자동 갱신