### PR TITLE
fix: 앱 재시작 시 streakDays가 4일에서 2일로 깎이던 문제 수정

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -149,11 +149,16 @@ final class PetViewModel: ObservableObject {
             }
         }
 
+        // Pending 파일은 라이브 옵저버와 별개로 모든 이벤트가 append 된다.
+        // 이미 라이브로 처리된 이벤트가 재시작 시 다시 replay 되면 streakDays/통계가 망가지므로,
+        // lastActiveAt 이후에 발생한 이벤트(즉 앱이 꺼져 있을 때의 catch-up)만 처리한다.
+        let cursor = state.lastActiveAt
         let pending = EventBridge.drainFileEvents()
-        for event in pending {
+        let fresh = pending.filter { $0.timestamp > cursor }
+        for event in fresh {
             processor.process(event: event, state: &state)
         }
-        if !pending.isEmpty { save() }
+        if !fresh.isEmpty { save() }
 
         eventObserver = EventBridge.observe { [weak self] event in
             Task { @MainActor in self?.handleEvent(event) }

--- a/Sources/DamagochiCore/Events/FeedProcessor.swift
+++ b/Sources/DamagochiCore/Events/FeedProcessor.swift
@@ -153,6 +153,8 @@ public struct FeedProcessor: Sendable {
         guard lastDay != today else { return }
 
         let dayDiff = calendar.dateComponents([.day], from: lastDay, to: today).day ?? 0
+        // 과거 타임스탬프 이벤트가 들어와도 스트릭이 거꾸로 가지 않도록 방어.
+        guard dayDiff > 0 else { return }
         if dayDiff == 1 {
             state.streakDays += 1
         } else {

--- a/Tests/DamagochiCoreTests/FeedProcessorTests.swift
+++ b/Tests/DamagochiCoreTests/FeedProcessorTests.swift
@@ -76,3 +76,26 @@ import Testing
     let ids = Set(result.newAchievements.map(\.id))
     #expect(ids.contains("level_5"))
 }
+
+@Test func feedProcessorIgnoresStaleSessionStartForStreak() throws {
+    // 앱 재시작 시 pending 파일에서 과거 타임스탬프의 sessionStart 이벤트가 replay 되어도
+    // 이미 누적된 streakDays가 거꾸로 깎이지 않아야 한다.
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-streak")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    let twoDaysAgo = try #require(calendar.date(byAdding: .day, value: -2, to: today))
+    let yesterday = try #require(calendar.date(byAdding: .day, value: -1, to: today))
+
+    state.streakDays = 4
+    state.longestStreak = 4
+    state.lastStreakDate = today
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: twoDaysAgo), state: &state)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: yesterday), state: &state)
+
+    #expect(state.streakDays == 4)
+    #expect(state.lastStreakDate == today)
+}


### PR DESCRIPTION
EventBridge.post는 모든 이벤트를 라이브 옵저버와 pending-events.jsonl 양쪽에
보내는데, 파일은 앱 시작 시에만 비워지므로 라이브로 이미 처리된 이벤트들이
재시작(=업데이트) 시 다시 replay 되어 updateStreak이 과거 타임스탬프로 호출되어
streakDays가 망가졌다.

- PetViewModel.start: pending 이벤트 중 lastActiveAt 이후 발생한 것만 처리
- FeedProcessor.updateStreak: dayDiff <= 0인 과거 이벤트는 무시 (안전망)
- streakDays=4 상태에서 과거 sessionStart 두 개를 처리해도 4가 유지되는지 검증하는 회귀 테스트 추가

https://claude.ai/code/session_01PZZQRGvdht1SWVVYcZCLxu