### PR TITLE
fix: 설정 펫 정보의 연속 근무일이 항상 0으로 표시되던 문제 수정

### DIFF
--- a/Sources/DamagochiCore/Events/FeedProcessor.swift
+++ b/Sources/DamagochiCore/Events/FeedProcessor.swift
@@ -68,6 +68,7 @@ public struct FeedProcessor: Sendable {
         if case .sessionStart = event.kind {
             let prevLastDate = state.lastStreakDate
             updateStreak(state: &state, now: event.timestamp)
+            updateWorkdays(state: &state, now: event.timestamp)
             if state.lastStreakDate != prevLastDate {
                 streakUpdated = true
                 newStreakDays = state.streakDays
@@ -163,6 +164,49 @@ public struct FeedProcessor: Sendable {
         state.lastStreakDate = now
         state.longestStreak = max(state.longestStreak, state.streakDays)
         grantStreakMilestone(state: &state)
+    }
+
+    // MARK: - Workdays (영업일 연속 카운터)
+
+    private func updateWorkdays(state: inout PetState, now: Date) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        // 주말(토/일) 세션은 영업일 카운터에 영향을 주지 않는다.
+        let weekday = calendar.component(.weekday, from: today)
+        guard weekday != 1 && weekday != 7 else { return }
+
+        guard let lastDate = state.lastWorkdayDate else {
+            state.consecutiveWorkdays = 1
+            state.lastWorkdayDate = today
+            return
+        }
+
+        let lastDay = calendar.startOfDay(for: lastDate)
+        guard lastDay != today else { return }
+
+        let businessDayDiff = countBusinessDays(from: lastDay, to: today)
+        // 과거 타임스탬프 이벤트가 들어와도 카운터가 거꾸로 가지 않도록 방어.
+        guard businessDayDiff > 0 else { return }
+        if businessDayDiff == 1 {
+            state.consecutiveWorkdays += 1
+        } else {
+            state.consecutiveWorkdays = 1
+        }
+        state.lastWorkdayDate = today
+    }
+
+    private func countBusinessDays(from start: Date, to end: Date) -> Int {
+        let calendar = Calendar.current
+        var count = 0
+        var date = start
+        while date < end {
+            date = calendar.date(byAdding: .day, value: 1, to: date)!
+            let weekday = calendar.component(.weekday, from: date)
+            if weekday != 1 && weekday != 7 {
+                count += 1
+            }
+        }
+        return count
     }
 
     private func grantStreakMilestone(state: inout PetState) {

--- a/Sources/DamagochiCore/Models/PetState.swift
+++ b/Sources/DamagochiCore/Models/PetState.swift
@@ -65,6 +65,7 @@ public struct PetState: Codable, Sendable {
     public var streakDays: Int
     public var longestStreak: Int
     public var lastStreakDate: Date?
+    public var lastWorkdayDate: Date?
     public var bugsCaught: Int
     public var goldenBugsCaught: Int
     public var rainbowBugsCaught: Int
@@ -103,6 +104,7 @@ public struct PetState: Codable, Sendable {
         self.streakDays = 0
         self.longestStreak = 0
         self.lastStreakDate = nil
+        self.lastWorkdayDate = nil
         self.bugsCaught = 0
         self.goldenBugsCaught = 0
         self.rainbowBugsCaught = 0

--- a/Tests/DamagochiCoreTests/FeedProcessorTests.swift
+++ b/Tests/DamagochiCoreTests/FeedProcessorTests.swift
@@ -77,6 +77,110 @@ import Testing
     #expect(ids.contains("level_5"))
 }
 
+@Test func feedProcessorInitializesWorkdaysOnFirstBusinessDaySession() throws {
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    // 월요일 (weekday == 2)
+    var components = DateComponents(year: 2026, month: 1, day: 5, hour: 10)
+    let monday = try #require(Calendar.current.date(from: components))
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: monday), state: &state)
+
+    #expect(state.consecutiveWorkdays == 1)
+    #expect(state.lastWorkdayDate != nil)
+}
+
+@Test func feedProcessorIncrementsWorkdaysOnConsecutiveBusinessDays() throws {
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let monday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 5, hour: 10)))
+    let tuesday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 6, hour: 10)))
+    let wednesday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 7, hour: 10)))
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: monday), state: &state)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: tuesday), state: &state)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: wednesday), state: &state)
+
+    #expect(state.consecutiveWorkdays == 3)
+}
+
+@Test func feedProcessorBridgesWeekendForWorkdays() throws {
+    // 금요일 → 월요일은 주말을 건너뛰지만 영업일 기준으로는 연속이다.
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let friday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 2, hour: 10)))
+    let monday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 5, hour: 10)))
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: friday), state: &state)
+    #expect(state.consecutiveWorkdays == 1)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: monday), state: &state)
+    #expect(state.consecutiveWorkdays == 2)
+}
+
+@Test func feedProcessorResetsWorkdaysWhenBusinessDayMissed() throws {
+    // 월요일 → 수요일은 화요일을 건너뛰었으므로 카운터 리셋.
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let monday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 5, hour: 10)))
+    let wednesday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 7, hour: 10)))
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: monday), state: &state)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: wednesday), state: &state)
+
+    #expect(state.consecutiveWorkdays == 1)
+}
+
+@Test func feedProcessorIgnoresWeekendSessionForWorkdays() throws {
+    // 주말 세션은 영업일 카운터에 영향을 주지 않는다.
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let friday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 2, hour: 10)))
+    let saturday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 3, hour: 10)))
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: friday), state: &state)
+    let workdaysBefore = state.consecutiveWorkdays
+    let lastWorkdayBefore = state.lastWorkdayDate
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: saturday), state: &state)
+
+    #expect(state.consecutiveWorkdays == workdaysBefore)
+    #expect(state.lastWorkdayDate == lastWorkdayBefore)
+}
+
+@Test func feedProcessorIgnoresStaleSessionStartForWorkdays() throws {
+    // 과거 타임스탬프의 sessionStart가 replay 되어도 영업일 카운터가 거꾸로 가지 않는다.
+    let processor = FeedProcessor()
+    var state = PetState(machineId: "test-workdays")
+    state.phase = .alive
+
+    let calendar = Calendar.current
+    let monday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 5, hour: 10)))
+    let tuesday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 6, hour: 10)))
+    let wednesday = try #require(calendar.date(from: DateComponents(year: 2026, month: 1, day: 7, hour: 10)))
+
+    state.consecutiveWorkdays = 3
+    state.lastWorkdayDate = wednesday
+
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: monday), state: &state)
+    processor.process(event: BehaviorEvent(kind: .sessionStart, timestamp: tuesday), state: &state)
+
+    #expect(state.consecutiveWorkdays == 3)
+    #expect(state.lastWorkdayDate == wednesday)
+}
+
 @Test func feedProcessorIgnoresStaleSessionStartForStreak() throws {
     // 앱 재시작 시 pending 파일에서 과거 타임스탬프의 sessionStart 이벤트가 replay 되어도
     // 이미 누적된 streakDays가 거꾸로 깎이지 않아야 한다.


### PR DESCRIPTION
PetState.consecutiveWorkdays 필드가 SettingsView에 표시되고 영업일 도전과제(workdays_7/30/100) 조건에 사용되지만, 코드 어디에서도 증가시키지 않아 값이 항상 0에 머물렀음.

FeedProcessor에 sessionStart 이벤트 기반 updateWorkdays 로직을 추가하여 평일 세션마다 영업일을 누적하고, 영업일 사이에 평일을 거르면 1로 리셋, 주말은 카운터에 영향을 주지 않도록 처리. 마지막 영업일 기준일을 저장할 lastWorkdayDate 필드도 추가했고, 과거 타임스탬프 이벤트가 replay 되어도 카운터가 거꾸로 가지 않도록 방어함.