### PR TITLE
fix: 산책 말풍선이 나타날 때 화면이 위아래로 늘어지던 문제 수정

### DIFF
--- a/Sources/DamagochiApp/Views/WalkingWindowController.swift
+++ b/Sources/DamagochiApp/Views/WalkingWindowController.swift
@@ -1,10 +1,13 @@
 import AppKit
+import Combine
 import SwiftUI
 
 @MainActor
 final class WalkingWindowController {
     private var panel: NSPanel?
+    private var hostingController: NSHostingController<WalkingPetView>?
     private let viewModel: PetViewModel
+    private var cancellables: Set<AnyCancellable> = []
 
     init(viewModel: PetViewModel) {
         self.viewModel = viewModel
@@ -38,10 +41,36 @@ final class WalkingWindowController {
 
         panel.orderFront(nil)
         self.panel = panel
+        self.hostingController = hostingController
+
+        viewModel.$walkSpeechBubble
+            .removeDuplicates { ($0 == nil) == ($1 == nil) }
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.resizePanelKeepingBottom()
+            }
+            .store(in: &cancellables)
     }
 
     func hide() {
+        cancellables.removeAll()
         panel?.close()
         panel = nil
+        hostingController = nil
+    }
+
+    private func resizePanelKeepingBottom() {
+        guard let panel, let hostingController else { return }
+        // Wait one tick for SwiftUI to lay out the new content.
+        DispatchQueue.main.async { [weak panel, weak hostingController] in
+            guard let panel, let hostingController else { return }
+            let oldFrame = panel.frame
+            let newSize = hostingController.view.fittingSize
+            let newOrigin = NSPoint(
+                x: oldFrame.origin.x,
+                y: oldFrame.origin.y - (newSize.height - oldFrame.size.height)
+            )
+            panel.setFrame(NSRect(origin: newOrigin, size: newSize), display: true, animate: false)
+        }
     }
 }


### PR DESCRIPTION
말풍선 표시 시 패널이 위쪽으로 확장되도록 하여 펫 박스의
화면 위치는 그대로 유지되도록 수정.

https://claude.ai/code/session_01TcQZQesx8KgR7QX3zqsKj6