### PR TITLE
feat: 장착 아이템을 마우스 드래그로 위치 조정

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -73,14 +73,36 @@ final class PetViewModel: ObservableObject {
     private var petSpeechBubbleTimer: AnyCancellable?
     private var bugPopupTimer: AnyCancellable?
 
-    var currentFrames: [PixelSprite] {
+    var baseFrames: [PixelSprite] {
         SpriteSheet.frames(
             species: state.species,
             stage: state.stage,
-            phase: state.phase,
+            phase: state.phase
+        )
+    }
+
+    var equippedOverlays: [SpriteSheet.EquippedOverlay] {
+        guard state.phase == .alive else { return [] }
+        return SpriteSheet.equippedOverlays(
             equipped: state.equippedItems,
             inventory: state.inventory
         )
+    }
+
+    func equipmentOffset(for slot: EquipmentSlot) -> PixelOffset {
+        (state.equipmentOffsets ?? EquipmentOffsets()).offset(for: slot)
+    }
+
+    func setEquipmentOffset(_ offset: PixelOffset, for slot: EquipmentSlot) {
+        var offsets = state.equipmentOffsets ?? EquipmentOffsets()
+        guard offsets.offset(for: slot) != offset else { return }
+        offsets.setOffset(offset, for: slot)
+        state.equipmentOffsets = offsets
+    }
+
+    func resetEquipmentOffset(for slot: EquipmentSlot) {
+        setEquipmentOffset(.zero, for: slot)
+        save()
     }
 
     var statusMessage: String {

--- a/Sources/DamagochiApp/Views/EquippedPetView.swift
+++ b/Sources/DamagochiApp/Views/EquippedPetView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+import DamagochiCore
+import DamagochiRenderer
+
+/// Renders the pet with each equipped item as a separately-positioned overlay
+/// so the user can drag any item with the mouse to reposition it.
+struct EquippedPetView: View {
+    @ObservedObject var viewModel: PetViewModel
+    let scale: CGFloat
+    let interval: TimeInterval
+
+    var body: some View {
+        let baseFrames = viewModel.baseFrames
+        let baseWidth = CGFloat(baseFrames.first?.width ?? 16) * scale
+        let baseHeight = CGFloat(baseFrames.first?.height ?? 16) * scale
+
+        ZStack {
+            AnimatedPetView(frames: baseFrames, scale: scale, interval: interval)
+
+            ForEach(viewModel.equippedOverlays, id: \.slot) { overlay in
+                DraggableEquipmentOverlay(
+                    viewModel: viewModel,
+                    overlay: overlay,
+                    scale: scale
+                )
+            }
+        }
+        .frame(width: baseWidth, height: baseHeight)
+    }
+}
+
+private struct DraggableEquipmentOverlay: View {
+    @ObservedObject var viewModel: PetViewModel
+    let overlay: SpriteSheet.EquippedOverlay
+    let scale: CGFloat
+
+    @State private var dragStart: PixelOffset?
+    @State private var isHovering = false
+
+    var body: some View {
+        let off = viewModel.equipmentOffset(for: overlay.slot)
+        let bounds = overlay.sprite.visibleBounds
+            ?? CGRect(x: 0, y: 0, width: overlay.sprite.width, height: overlay.sprite.height)
+        let scaledBounds = CGRect(
+            x: bounds.minX * scale,
+            y: bounds.minY * scale,
+            width: bounds.width * scale,
+            height: bounds.height * scale
+        )
+
+        PixelArtView(sprite: overlay.sprite, scale: scale)
+            .overlay(
+                OverlayHitShape(rect: scaledBounds)
+                    .stroke(
+                        Color.accentColor.opacity(isHovering || dragStart != nil ? 0.85 : 0),
+                        style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+                    )
+                    .allowsHitTesting(false)
+            )
+            .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
+            .contentShape(OverlayHitShape(rect: scaledBounds))
+            .onHover { isHovering = $0 }
+            .help("드래그해서 위치 조정 · 더블클릭으로 초기화")
+            .onTapGesture(count: 2) {
+                viewModel.resetEquipmentOffset(for: overlay.slot)
+            }
+            .gesture(dragGesture(currentOffset: off))
+    }
+
+    private func dragGesture(currentOffset: PixelOffset) -> some Gesture {
+        DragGesture(minimumDistance: 1)
+            .onChanged { value in
+                if dragStart == nil { dragStart = currentOffset }
+                let start = dragStart ?? currentOffset
+                let dx = Int((value.translation.width / scale).rounded())
+                let dy = Int((value.translation.height / scale).rounded())
+                viewModel.setEquipmentOffset(
+                    PixelOffset(x: start.x + dx, y: start.y + dy),
+                    for: overlay.slot
+                )
+            }
+            .onEnded { _ in
+                dragStart = nil
+                viewModel.save()
+            }
+    }
+}
+
+/// Restricts hit-testing to the sprite's non-transparent bounding rectangle so
+/// that overlays can be picked individually even when their 16x16 frames overlap.
+private struct OverlayHitShape: Shape {
+    let rect: CGRect
+    func path(in _: CGRect) -> Path {
+        Path(rect)
+    }
+}

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -99,8 +99,8 @@ struct PopoverView: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(.quaternary.opacity(0.3))
 
-            AnimatedPetView(
-                frames: viewModel.currentFrames,
+            EquippedPetView(
+                viewModel: viewModel,
                 scale: 8.0,
                 interval: 0.5
             )

--- a/Sources/DamagochiApp/Views/WalkingPetView.swift
+++ b/Sources/DamagochiApp/Views/WalkingPetView.swift
@@ -18,8 +18,8 @@ struct WalkingPetView: View {
                     .shadow(radius: 6)
 
                 VStack(spacing: 8) {
-                    AnimatedPetView(
-                        frames: viewModel.currentFrames,
+                    EquippedPetView(
+                        viewModel: viewModel,
                         scale: 6.0,
                         interval: 0.5
                     )

--- a/Sources/DamagochiCore/Models/PetState.swift
+++ b/Sources/DamagochiCore/Models/PetState.swift
@@ -38,6 +38,50 @@ public struct EquippedItems: Codable, Sendable {
     }
 }
 
+public struct PixelOffset: Codable, Sendable, Equatable {
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int = 0, y: Int = 0) {
+        self.x = x
+        self.y = y
+    }
+
+    public static let zero = PixelOffset(x: 0, y: 0)
+}
+
+public struct EquipmentOffsets: Codable, Sendable, Equatable {
+    public var head: PixelOffset
+    public var hand: PixelOffset
+    public var effect: PixelOffset
+
+    public init(
+        head: PixelOffset = .zero,
+        hand: PixelOffset = .zero,
+        effect: PixelOffset = .zero
+    ) {
+        self.head = head
+        self.hand = hand
+        self.effect = effect
+    }
+
+    public func offset(for slot: EquipmentSlot) -> PixelOffset {
+        switch slot {
+        case .head:   return head
+        case .hand:   return hand
+        case .effect: return effect
+        }
+    }
+
+    public mutating func setOffset(_ offset: PixelOffset, for slot: EquipmentSlot) {
+        switch slot {
+        case .head:   head = offset
+        case .hand:   hand = offset
+        case .effect: effect = offset
+        }
+    }
+}
+
 public struct PetState: Codable, Sendable {
     public var machineId: String
     public var phase: PetPhase
@@ -52,6 +96,7 @@ public struct PetState: Codable, Sendable {
     public var mbtiScores: MbtiScores
     public var personality: String?
     public var equippedItems: EquippedItems
+    public var equipmentOffsets: EquipmentOffsets?
     public var inventory: [Equipment]
     public var unlockedAchievements: [String]
     public var graveyardEntries: [GraveyardEntry]
@@ -91,6 +136,7 @@ public struct PetState: Codable, Sendable {
         self.mbtiScores = MbtiScores()
         self.personality = nil
         self.equippedItems = EquippedItems()
+        self.equipmentOffsets = EquipmentOffsets()
         self.inventory = []
         self.unlockedAchievements = []
         self.graveyardEntries = []

--- a/Sources/DamagochiRenderer/PixelArtRenderer.swift
+++ b/Sources/DamagochiRenderer/PixelArtRenderer.swift
@@ -95,6 +95,23 @@ public struct PixelSprite: Sendable {
         return PixelSprite(width: width, height: height, pixels: result)
     }
 
+    /// Tight bounding box of non-transparent pixels, in pixel-grid coordinates.
+    public var visibleBounds: CGRect? {
+        var minX = width, minY = height, maxX = -1, maxY = -1
+        for row in 0..<height {
+            for col in 0..<width {
+                if !pixels[row][col].isTransparent {
+                    if col < minX { minX = col }
+                    if col > maxX { maxX = col }
+                    if row < minY { minY = row }
+                    if row > maxY { maxY = row }
+                }
+            }
+        }
+        guard maxX >= 0 else { return nil }
+        return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
+    }
+
     public static let empty = PixelSprite(width: 0, height: 0, pixels: [])
 }
 

--- a/Sources/DamagochiRenderer/SpriteSheet.swift
+++ b/Sources/DamagochiRenderer/SpriteSheet.swift
@@ -5340,6 +5340,29 @@ public enum SpriteSheet {
 
     // MARK: - Equipment Overlays
 
+    public struct EquippedOverlay: Sendable {
+        public let slot: EquipmentSlot
+        public let item: Equipment
+        public let sprite: PixelSprite
+    }
+
+    public static func equippedOverlays(
+        equipped: EquippedItems,
+        inventory: [Equipment]
+    ) -> [EquippedOverlay] {
+        var result: [EquippedOverlay] = []
+        if let id = equipped.head, let item = inventory.first(where: { $0.id == id }) {
+            result.append(EquippedOverlay(slot: .head, item: item, sprite: headOverlay(item: item)))
+        }
+        if let id = equipped.hand, let item = inventory.first(where: { $0.id == id }) {
+            result.append(EquippedOverlay(slot: .hand, item: item, sprite: handOverlay(item: item)))
+        }
+        if let id = equipped.effect, let item = inventory.first(where: { $0.id == id }) {
+            result.append(EquippedOverlay(slot: .effect, item: item, sprite: effectOverlay(item: item)))
+        }
+        return result
+    }
+
     public static func frames(
         species: String?,
         stage: Stage,
@@ -5350,12 +5373,7 @@ public enum SpriteSheet {
         let base = frames(species: species, stage: stage, phase: phase)
         guard phase == .alive else { return base }
 
-        let overlayList: [PixelSprite] = [
-            equipped.head.flatMap { id in inventory.first { $0.id == id } }.map { headOverlay(item: $0) },
-            equipped.hand.flatMap { id in inventory.first { $0.id == id } }.map { handOverlay(item: $0) },
-            equipped.effect.flatMap { id in inventory.first { $0.id == id } }.map { effectOverlay(item: $0) },
-        ].compactMap { $0 }
-
+        let overlayList = equippedOverlays(equipped: equipped, inventory: inventory).map { $0.sprite }
         guard !overlayList.isEmpty else { return base }
         return base.map { frame in overlayList.reduce(frame) { $0.overlaid(with: $1) } }
     }


### PR DESCRIPTION
- PetState에 슬롯별 픽셀 오프셋(EquipmentOffsets) 저장
- SpriteSheet.equippedOverlays로 슬롯별 오버레이 스프라이트 노출
- EquippedPetView로 펫 본체와 오버레이를 분리 렌더링하고 각 오버레이에 드래그 제스처 부착 (더블클릭 시 위치 초기화)
- PopoverView/WalkingPetView가 새 뷰 사용