### PR TITLE
feat: 장비 탭에서만 아이템 위치 조정, 픽셀 단위 히트테스트 적용

### DIFF
--- a/Sources/DamagochiApp/Views/EquippedPetView.swift
+++ b/Sources/DamagochiApp/Views/EquippedPetView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 import DamagochiCore
 import DamagochiRenderer
 
-/// Renders the pet with each equipped item as a separately-positioned overlay
-/// so the user can drag any item with the mouse to reposition it.
+/// Renders the pet with each equipped item overlaid.
+/// When `isDraggable` is true, each item can be dragged to reposition it.
 struct EquippedPetView: View {
     @ObservedObject var viewModel: PetViewModel
     let scale: CGFloat
     let interval: TimeInterval
+    var isDraggable: Bool = false
 
     var body: some View {
         let baseFrames = viewModel.baseFrames
@@ -18,16 +19,41 @@ struct EquippedPetView: View {
             AnimatedPetView(frames: baseFrames, scale: scale, interval: interval)
 
             ForEach(viewModel.equippedOverlays, id: \.slot) { overlay in
-                DraggableEquipmentOverlay(
-                    viewModel: viewModel,
-                    overlay: overlay,
-                    scale: scale
-                )
+                if isDraggable {
+                    DraggableEquipmentOverlay(
+                        viewModel: viewModel,
+                        overlay: overlay,
+                        scale: scale
+                    )
+                } else {
+                    StaticEquipmentOverlay(
+                        viewModel: viewModel,
+                        overlay: overlay,
+                        scale: scale
+                    )
+                }
             }
         }
         .frame(width: baseWidth, height: baseHeight)
     }
 }
+
+// MARK: - Static Overlay (read-only, no interaction)
+
+private struct StaticEquipmentOverlay: View {
+    @ObservedObject var viewModel: PetViewModel
+    let overlay: SpriteSheet.EquippedOverlay
+    let scale: CGFloat
+
+    var body: some View {
+        let off = viewModel.equipmentOffset(for: overlay.slot)
+        PixelArtView(sprite: overlay.sprite, scale: scale)
+            .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
+            .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Draggable Overlay
 
 private struct DraggableEquipmentOverlay: View {
     @ObservedObject var viewModel: PetViewModel
@@ -58,7 +84,7 @@ private struct DraggableEquipmentOverlay: View {
                     .allowsHitTesting(false)
             )
             .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
-            .contentShape(OverlayHitShape(rect: scaledBounds))
+            .contentShape(PixelHitShape(sprite: overlay.sprite, scale: scale))
             .onHover { isHovering = $0 }
             .help("드래그해서 위치 조정 · 더블클릭으로 초기화")
             .onTapGesture(count: 2) {
@@ -86,11 +112,35 @@ private struct DraggableEquipmentOverlay: View {
     }
 }
 
-/// Restricts hit-testing to the sprite's non-transparent bounding rectangle so
-/// that overlays can be picked individually even when their 16x16 frames overlap.
+// MARK: - Shapes
+
+/// Bounding-box shape used for the dashed visual border.
 private struct OverlayHitShape: Shape {
     let rect: CGRect
     func path(in _: CGRect) -> Path {
         Path(rect)
+    }
+}
+
+/// Pixel-accurate hit shape — only covers non-transparent pixels so overlapping
+/// overlays don't block each other's drag gestures.
+private struct PixelHitShape: Shape {
+    let sprite: PixelSprite
+    let scale: CGFloat
+
+    func path(in _: CGRect) -> Path {
+        var path = Path()
+        for row in 0..<sprite.height {
+            for col in 0..<sprite.width {
+                guard !sprite.pixels[row][col].isTransparent else { continue }
+                path.addRect(CGRect(
+                    x: CGFloat(col) * scale,
+                    y: CGFloat(row) * scale,
+                    width: scale,
+                    height: scale
+                ))
+            }
+        }
+        return path
     }
 }

--- a/Sources/DamagochiApp/Views/InventoryView.swift
+++ b/Sources/DamagochiApp/Views/InventoryView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import DamagochiCore
+import DamagochiRenderer
 
 struct InventoryView: View {
     @ObservedObject var viewModel: PetViewModel
@@ -33,11 +34,15 @@ struct InventoryView: View {
         .padding(.vertical, 8)
     }
 
-    // MARK: - Equipped Slots
+    // MARK: - Content
 
     private var inventoryContent: some View {
         ScrollView {
             VStack(spacing: 10) {
+                if viewModel.state.phase == .alive && hasEquippedItems {
+                    positionSection
+                    Divider()
+                }
                 equippedSection
                 Divider()
                 allItemsSection
@@ -46,6 +51,42 @@ struct InventoryView: View {
             .frame(maxWidth: .infinity)
         }
     }
+
+    // MARK: - Position Adjustment Section
+
+    private var hasEquippedItems: Bool {
+        viewModel.state.equippedItems.head != nil ||
+        viewModel.state.equippedItems.hand != nil ||
+        viewModel.state.equippedItems.effect != nil
+    }
+
+    private var positionSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("위치 조정")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.quaternary.opacity(0.3))
+
+                EquippedPetView(
+                    viewModel: viewModel,
+                    scale: 7.0,
+                    interval: 0.5,
+                    isDraggable: true
+                )
+            }
+            .frame(height: 120)
+
+            Text("아이템을 드래그하여 위치를 조정하세요 · 더블클릭으로 초기화")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
+
+    // MARK: - Equipped Slots
 
     private var equippedSection: some View {
         VStack(alignment: .leading, spacing: 6) {

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -395,14 +395,25 @@ struct PopoverView: View {
 struct StateAnimationModifier: ViewModifier {
     let state: PetState
 
+    @State private var bounceOffset: CGFloat = 0
+    @State private var wobbleAngle: Angle = .zero
+
     func body(content: Content) -> some View {
         content
             .offset(y: state.phase == .alive && state.mood > 80 ? bounceOffset : 0)
             .rotationEffect(state.hunger < 20 ? wobbleAngle : .zero)
             .saturation(state.phase == .dead ? 0 : 1)
-            .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: state.mood)
+            .onAppear {
+                if state.phase == .alive && state.mood > 80 {
+                    withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                        bounceOffset = -4
+                    }
+                }
+                if state.hunger < 20 {
+                    withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
+                        wobbleAngle = .degrees(3)
+                    }
+                }
+            }
     }
-
-    @State private var bounceOffset: CGFloat = -3
-    @State private var wobbleAngle: Angle = .degrees(-3)
 }


### PR DESCRIPTION
- EquippedPetView에 isDraggable 파라미터 추가 (기본값 false)
  - isDraggable=true: DraggableEquipmentOverlay (드래그 가능)
  - isDraggable=false: StaticEquipmentOverlay (표시만, 인터랙션 없음)
- PixelHitShape 추가: 불투명 픽셀에만 히트테스트 적용하여
  여러 아이템이 겹쳐도 각각 독립적으로 드래그 가능
- InventoryView에 위치 조정용 펫 미리보기 섹션 추가
  (아이템 장착 중일 때만 표시)
- 펫 상태 화면, 산책 화면은 정적 표시로 변경
- StateAnimationModifier 수정: bounceOffset 초기값 0으로
  변경하고 onAppear에서 애니메이션 시작하여 캐릭터 중앙 정렬

https://claude.ai/code/session_011KX1ZytQqxZ1HTUyTfABQg