### PR TITLE
fix: effect 아이템 z-index 충돌 수정 및 캐릭터 위치 조정

### DIFF
--- a/Sources/DamagochiApp/Views/EquippedPetView.swift
+++ b/Sources/DamagochiApp/Views/EquippedPetView.swift
@@ -3,7 +3,8 @@ import DamagochiCore
 import DamagochiRenderer
 
 /// Renders the pet with each equipped item overlaid.
-/// When `isDraggable` is true, each item can be dragged to reposition it.
+/// When `isDraggable` is true (inventory tab only), each item can be dragged
+/// to reposition it. In all other views `isDraggable` stays false.
 struct EquippedPetView: View {
     @ObservedObject var viewModel: PetViewModel
     let scale: CGFloat
@@ -14,23 +15,38 @@ struct EquippedPetView: View {
         let baseFrames = viewModel.baseFrames
         let baseWidth = CGFloat(baseFrames.first?.width ?? 16) * scale
         let baseHeight = CGFloat(baseFrames.first?.height ?? 16) * scale
+        let overlays = viewModel.equippedOverlays
 
         ZStack {
             AnimatedPetView(frames: baseFrames, scale: scale, interval: interval)
 
-            ForEach(viewModel.equippedOverlays, id: \.slot) { overlay in
-                if isDraggable {
-                    DraggableEquipmentOverlay(
-                        viewModel: viewModel,
-                        overlay: overlay,
-                        scale: scale
-                    )
-                } else {
-                    StaticEquipmentOverlay(
-                        viewModel: viewModel,
-                        overlay: overlay,
-                        scale: scale
-                    )
+            if isDraggable {
+                // Effect is split into two separate layers to avoid blocking
+                // head/hand drag gestures:
+                //   1. Effect INTERACTION at the bottom (lowest hit-test priority)
+                //   2. Effect VISUAL at the top (highest z, no hit testing)
+                // Head/hand overlays sit in-between with pixel-accurate hit shapes.
+
+                let effectOverlay = overlays.first(where: { $0.slot == .effect })
+                let otherOverlays = overlays.filter { $0.slot != .effect }
+
+                // Layer 1: effect drag handle (invisible, bottom of ZStack)
+                if let effect = effectOverlay {
+                    EffectInteractionOverlay(viewModel: viewModel, overlay: effect, scale: scale)
+                }
+
+                // Layer 2 & 3: head / hand (pixel-accurate hit shapes)
+                ForEach(otherOverlays, id: \.slot) { overlay in
+                    DraggableEquipmentOverlay(viewModel: viewModel, overlay: overlay, scale: scale)
+                }
+
+                // Layer 4: effect visual (top, allowsHitTesting false)
+                if let effect = effectOverlay {
+                    StaticEquipmentOverlay(viewModel: viewModel, overlay: effect, scale: scale)
+                }
+            } else {
+                ForEach(overlays, id: \.slot) { overlay in
+                    StaticEquipmentOverlay(viewModel: viewModel, overlay: overlay, scale: scale)
                 }
             }
         }
@@ -38,7 +54,7 @@ struct EquippedPetView: View {
     }
 }
 
-// MARK: - Static Overlay (read-only, no interaction)
+// MARK: - Static Overlay
 
 private struct StaticEquipmentOverlay: View {
     @ObservedObject var viewModel: PetViewModel
@@ -53,7 +69,7 @@ private struct StaticEquipmentOverlay: View {
     }
 }
 
-// MARK: - Draggable Overlay
+// MARK: - Draggable Overlay (head / hand)
 
 private struct DraggableEquipmentOverlay: View {
     @ObservedObject var viewModel: PetViewModel
@@ -112,17 +128,82 @@ private struct DraggableEquipmentOverlay: View {
     }
 }
 
-// MARK: - Shapes
+// MARK: - Effect Interaction Overlay (invisible, lowest hit priority)
 
-/// Bounding-box shape used for the dashed visual border.
-private struct OverlayHitShape: Shape {
-    let rect: CGRect
-    func path(in _: CGRect) -> Path {
-        Path(rect)
+/// Transparent drag handle for the effect slot.
+/// Rendered at the BOTTOM of the draggable ZStack so head/hand overlays
+/// take hit-test priority. The actual effect pixels are drawn by a
+/// StaticEquipmentOverlay at the top (no hit testing).
+private struct EffectInteractionOverlay: View {
+    @ObservedObject var viewModel: PetViewModel
+    let overlay: SpriteSheet.EquippedOverlay
+    let scale: CGFloat
+
+    @State private var dragStart: PixelOffset?
+    @State private var isHovering = false
+
+    var body: some View {
+        let off = viewModel.equipmentOffset(for: overlay.slot)
+        let bounds = overlay.sprite.visibleBounds
+            ?? CGRect(x: 0, y: 0, width: overlay.sprite.width, height: overlay.sprite.height)
+        let scaledBounds = CGRect(
+            x: bounds.minX * scale,
+            y: bounds.minY * scale,
+            width: bounds.width * scale,
+            height: bounds.height * scale
+        )
+
+        Rectangle()
+            .fill(Color.white.opacity(0.001))
+            .frame(
+                width: CGFloat(overlay.sprite.width) * scale,
+                height: CGFloat(overlay.sprite.height) * scale
+            )
+            .overlay(
+                OverlayHitShape(rect: scaledBounds)
+                    .stroke(
+                        Color.accentColor.opacity(isHovering || dragStart != nil ? 0.85 : 0),
+                        style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+                    )
+                    .allowsHitTesting(false)
+            )
+            .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
+            .contentShape(OverlayHitShape(rect: scaledBounds))
+            .onHover { isHovering = $0 }
+            .help("효과 드래그해서 위치 조정 · 더블클릭으로 초기화")
+            .onTapGesture(count: 2) {
+                viewModel.resetEquipmentOffset(for: overlay.slot)
+            }
+            .gesture(dragGesture(currentOffset: off))
+    }
+
+    private func dragGesture(currentOffset: PixelOffset) -> some Gesture {
+        DragGesture(minimumDistance: 1)
+            .onChanged { value in
+                if dragStart == nil { dragStart = currentOffset }
+                let start = dragStart ?? currentOffset
+                let dx = Int((value.translation.width / scale).rounded())
+                let dy = Int((value.translation.height / scale).rounded())
+                viewModel.setEquipmentOffset(
+                    PixelOffset(x: start.x + dx, y: start.y + dy),
+                    for: overlay.slot
+                )
+            }
+            .onEnded { _ in
+                dragStart = nil
+                viewModel.save()
+            }
     }
 }
 
-/// Pixel-accurate hit shape — only covers non-transparent pixels so overlapping
+// MARK: - Shapes
+
+private struct OverlayHitShape: Shape {
+    let rect: CGRect
+    func path(in _: CGRect) -> Path { Path(rect) }
+}
+
+/// Pixel-accurate hit shape — only covers non-transparent pixels so head/hand
 /// overlays don't block each other's drag gestures.
 private struct PixelHitShape: Shape {
     let sprite: PixelSprite

--- a/Sources/DamagochiApp/Views/InventoryView.swift
+++ b/Sources/DamagochiApp/Views/InventoryView.swift
@@ -76,8 +76,10 @@ struct InventoryView: View {
                     interval: 0.5,
                     isDraggable: true
                 )
+                // Shift down so hat pixels don't clip into the rounded corner
+                .offset(y: 6)
             }
-            .frame(height: 120)
+            .frame(height: 128)
 
             Text("아이템을 드래그하여 위치를 조정하세요 · 더블클릭으로 초기화")
                 .font(.caption2)

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -104,6 +104,8 @@ struct PopoverView: View {
                 scale: 8.0,
                 interval: 0.5
             )
+            // Shift down so hat pixels don't clip into the rounded corner at the top
+            .offset(y: 8)
             .modifier(StateAnimationModifier(state: viewModel.state))
 
             bugOverlay
@@ -117,7 +119,7 @@ struct PopoverView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .frame(height: 140)
+        .frame(height: 148)
         .animation(.easeOut(duration: 0.3), value: viewModel.bugXPPopup)
     }
 


### PR DESCRIPTION
## Summary

- **z-index 버그 수정**: 3개 아이템 모두 장착 시 effect만 드래그되던 문제 근본 해결
- **캐릭터 위치 조정**: 모자가 둥근 모서리 위로 뚫고 올라가던 현상 수정

## 변경 상세

### z-index 문제 근본 해결
effect 스프라이트 픽셀이 전체 영역에 산재해 ZStack 최상단에서 모든 이벤트를 가로채던 문제를 레이어 분리로 해결:
- `EffectInteractionOverlay`: 투명한 드래그 핸들, ZStack 맨 아래 배치 → hit test 우선순위 최저
- `StaticEquipmentOverlay(effect)`: 시각 렌더링만, `allowsHitTesting(false)` 적용
- head/hand: `PixelHitShape`로 실제 픽셀에만 hit test 반응

3개 아이템 모두 장착 시 각각 독립적으로 드래그 가능

### 캐릭터 위치 조정
- PopoverView: `y+8` 오프셋, 컨테이너 높이 148px로 증가
- InventoryView 미리보기: `y+6` 오프셋, 컨테이너 높이 128px로 증가
- 모자가 둥근 모서리 위로 뚫고 올라가는 현상 해결

## Test plan

- [ ] 모자(head), 손(hand), 효과(effect) 3개 모두 장착 후 각각 독립적으로 드래그 가능한지 확인
- [ ] 모자 착용 시 캐릭터 영역 위로 뚫고 나오지 않는지 확인
- [ ] 더블클릭으로 위치 초기화 동작 확인

https://claude.ai/code/session_011KX1ZytQqxZ1HTUyTfABQg

---
_Generated by [Claude Code](https://claude.ai/code/session_011KX1ZytQqxZ1HTUyTfABQg)_