### PR TITLE
feat: 아이템 위치 키보드 조정 및 캐릭터 위치 개선

### DIFF
--- a/Sources/DamagochiApp/Views/EquippedPetView.swift
+++ b/Sources/DamagochiApp/Views/EquippedPetView.swift
@@ -3,13 +3,12 @@ import DamagochiCore
 import DamagochiRenderer
 
 /// Renders the pet with each equipped item overlaid.
-/// When `isDraggable` is true (inventory tab only), each item can be dragged
-/// to reposition it. In all other views `isDraggable` stays false.
+/// Pass `highlightedSlot` to draw a dashed selection border around that slot's item.
 struct EquippedPetView: View {
     @ObservedObject var viewModel: PetViewModel
     let scale: CGFloat
     let interval: TimeInterval
-    var isDraggable: Bool = false
+    var highlightedSlot: EquipmentSlot? = nil
 
     var body: some View {
         let baseFrames = viewModel.baseFrames
@@ -17,37 +16,29 @@ struct EquippedPetView: View {
         let baseHeight = CGFloat(baseFrames.first?.height ?? 16) * scale
         let overlays = viewModel.equippedOverlays
 
+        let effectOverlay = overlays.first(where: { $0.slot == .effect })
+        let otherOverlays = overlays.filter { $0.slot != .effect }
+
         ZStack {
             AnimatedPetView(frames: baseFrames, scale: scale, interval: interval)
 
-            if isDraggable {
-                // Effect is split into two separate layers to avoid blocking
-                // head/hand drag gestures:
-                //   1. Effect INTERACTION at the bottom (lowest hit-test priority)
-                //   2. Effect VISUAL at the top (highest z, no hit testing)
-                // Head/hand overlays sit in-between with pixel-accurate hit shapes.
+            ForEach(otherOverlays, id: \.slot) { overlay in
+                StaticEquipmentOverlay(
+                    viewModel: viewModel,
+                    overlay: overlay,
+                    scale: scale,
+                    isHighlighted: highlightedSlot == overlay.slot
+                )
+            }
 
-                let effectOverlay = overlays.first(where: { $0.slot == .effect })
-                let otherOverlays = overlays.filter { $0.slot != .effect }
-
-                // Layer 1: effect drag handle (invisible, bottom of ZStack)
-                if let effect = effectOverlay {
-                    EffectInteractionOverlay(viewModel: viewModel, overlay: effect, scale: scale)
-                }
-
-                // Layer 2 & 3: head / hand (pixel-accurate hit shapes)
-                ForEach(otherOverlays, id: \.slot) { overlay in
-                    DraggableEquipmentOverlay(viewModel: viewModel, overlay: overlay, scale: scale)
-                }
-
-                // Layer 4: effect visual (top, allowsHitTesting false)
-                if let effect = effectOverlay {
-                    StaticEquipmentOverlay(viewModel: viewModel, overlay: effect, scale: scale)
-                }
-            } else {
-                ForEach(overlays, id: \.slot) { overlay in
-                    StaticEquipmentOverlay(viewModel: viewModel, overlay: overlay, scale: scale)
-                }
+            // Effect renders on top visually
+            if let effect = effectOverlay {
+                StaticEquipmentOverlay(
+                    viewModel: viewModel,
+                    overlay: effect,
+                    scale: scale,
+                    isHighlighted: highlightedSlot == effect.slot
+                )
             }
         }
         .frame(width: baseWidth, height: baseHeight)
@@ -60,168 +51,37 @@ private struct StaticEquipmentOverlay: View {
     @ObservedObject var viewModel: PetViewModel
     let overlay: SpriteSheet.EquippedOverlay
     let scale: CGFloat
+    var isHighlighted: Bool = false
 
     var body: some View {
         let off = viewModel.equipmentOffset(for: overlay.slot)
-        PixelArtView(sprite: overlay.sprite, scale: scale)
+        let sprite = overlay.sprite
+        let bounds = sprite.visibleBounds
+            ?? CGRect(x: 0, y: 0, width: sprite.width, height: sprite.height)
+        let scaledBounds = CGRect(
+            x: bounds.minX * scale,
+            y: bounds.minY * scale,
+            width: bounds.width * scale,
+            height: bounds.height * scale
+        )
+
+        PixelArtView(sprite: sprite, scale: scale)
+            .overlay(
+                OverlayHitShape(rect: scaledBounds)
+                    .stroke(
+                        Color.accentColor.opacity(isHighlighted ? 0.9 : 0),
+                        style: StrokeStyle(lineWidth: 1.5, dash: [4, 2])
+                    )
+                    .allowsHitTesting(false)
+            )
             .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
             .allowsHitTesting(false)
     }
 }
 
-// MARK: - Draggable Overlay (head / hand)
-
-private struct DraggableEquipmentOverlay: View {
-    @ObservedObject var viewModel: PetViewModel
-    let overlay: SpriteSheet.EquippedOverlay
-    let scale: CGFloat
-
-    @State private var dragStart: PixelOffset?
-    @State private var isHovering = false
-
-    var body: some View {
-        let off = viewModel.equipmentOffset(for: overlay.slot)
-        let bounds = overlay.sprite.visibleBounds
-            ?? CGRect(x: 0, y: 0, width: overlay.sprite.width, height: overlay.sprite.height)
-        let scaledBounds = CGRect(
-            x: bounds.minX * scale,
-            y: bounds.minY * scale,
-            width: bounds.width * scale,
-            height: bounds.height * scale
-        )
-
-        PixelArtView(sprite: overlay.sprite, scale: scale)
-            .overlay(
-                OverlayHitShape(rect: scaledBounds)
-                    .stroke(
-                        Color.accentColor.opacity(isHovering || dragStart != nil ? 0.85 : 0),
-                        style: StrokeStyle(lineWidth: 1, dash: [3, 2])
-                    )
-                    .allowsHitTesting(false)
-            )
-            .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
-            .contentShape(PixelHitShape(sprite: overlay.sprite, scale: scale))
-            .onHover { isHovering = $0 }
-            .help("드래그해서 위치 조정 · 더블클릭으로 초기화")
-            .onTapGesture(count: 2) {
-                viewModel.resetEquipmentOffset(for: overlay.slot)
-            }
-            .gesture(dragGesture(currentOffset: off))
-    }
-
-    private func dragGesture(currentOffset: PixelOffset) -> some Gesture {
-        DragGesture(minimumDistance: 1)
-            .onChanged { value in
-                if dragStart == nil { dragStart = currentOffset }
-                let start = dragStart ?? currentOffset
-                let dx = Int((value.translation.width / scale).rounded())
-                let dy = Int((value.translation.height / scale).rounded())
-                viewModel.setEquipmentOffset(
-                    PixelOffset(x: start.x + dx, y: start.y + dy),
-                    for: overlay.slot
-                )
-            }
-            .onEnded { _ in
-                dragStart = nil
-                viewModel.save()
-            }
-    }
-}
-
-// MARK: - Effect Interaction Overlay (invisible, lowest hit priority)
-
-/// Transparent drag handle for the effect slot.
-/// Rendered at the BOTTOM of the draggable ZStack so head/hand overlays
-/// take hit-test priority. The actual effect pixels are drawn by a
-/// StaticEquipmentOverlay at the top (no hit testing).
-private struct EffectInteractionOverlay: View {
-    @ObservedObject var viewModel: PetViewModel
-    let overlay: SpriteSheet.EquippedOverlay
-    let scale: CGFloat
-
-    @State private var dragStart: PixelOffset?
-    @State private var isHovering = false
-
-    var body: some View {
-        let off = viewModel.equipmentOffset(for: overlay.slot)
-        let bounds = overlay.sprite.visibleBounds
-            ?? CGRect(x: 0, y: 0, width: overlay.sprite.width, height: overlay.sprite.height)
-        let scaledBounds = CGRect(
-            x: bounds.minX * scale,
-            y: bounds.minY * scale,
-            width: bounds.width * scale,
-            height: bounds.height * scale
-        )
-
-        Rectangle()
-            .fill(Color.white.opacity(0.001))
-            .frame(
-                width: CGFloat(overlay.sprite.width) * scale,
-                height: CGFloat(overlay.sprite.height) * scale
-            )
-            .overlay(
-                OverlayHitShape(rect: scaledBounds)
-                    .stroke(
-                        Color.accentColor.opacity(isHovering || dragStart != nil ? 0.85 : 0),
-                        style: StrokeStyle(lineWidth: 1, dash: [3, 2])
-                    )
-                    .allowsHitTesting(false)
-            )
-            .offset(x: CGFloat(off.x) * scale, y: CGFloat(off.y) * scale)
-            .contentShape(OverlayHitShape(rect: scaledBounds))
-            .onHover { isHovering = $0 }
-            .help("효과 드래그해서 위치 조정 · 더블클릭으로 초기화")
-            .onTapGesture(count: 2) {
-                viewModel.resetEquipmentOffset(for: overlay.slot)
-            }
-            .gesture(dragGesture(currentOffset: off))
-    }
-
-    private func dragGesture(currentOffset: PixelOffset) -> some Gesture {
-        DragGesture(minimumDistance: 1)
-            .onChanged { value in
-                if dragStart == nil { dragStart = currentOffset }
-                let start = dragStart ?? currentOffset
-                let dx = Int((value.translation.width / scale).rounded())
-                let dy = Int((value.translation.height / scale).rounded())
-                viewModel.setEquipmentOffset(
-                    PixelOffset(x: start.x + dx, y: start.y + dy),
-                    for: overlay.slot
-                )
-            }
-            .onEnded { _ in
-                dragStart = nil
-                viewModel.save()
-            }
-    }
-}
-
-// MARK: - Shapes
+// MARK: - Shape
 
 private struct OverlayHitShape: Shape {
     let rect: CGRect
     func path(in _: CGRect) -> Path { Path(rect) }
-}
-
-/// Pixel-accurate hit shape — only covers non-transparent pixels so head/hand
-/// overlays don't block each other's drag gestures.
-private struct PixelHitShape: Shape {
-    let sprite: PixelSprite
-    let scale: CGFloat
-
-    func path(in _: CGRect) -> Path {
-        var path = Path()
-        for row in 0..<sprite.height {
-            for col in 0..<sprite.width {
-                guard !sprite.pixels[row][col].isTransparent else { continue }
-                path.addRect(CGRect(
-                    x: CGFloat(col) * scale,
-                    y: CGFloat(row) * scale,
-                    width: scale,
-                    height: scale
-                ))
-            }
-        }
-        return path
-    }
 }

--- a/Sources/DamagochiApp/Views/InventoryView.swift
+++ b/Sources/DamagochiApp/Views/InventoryView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import SwiftUI
 import DamagochiCore
 import DamagochiRenderer
 
 struct InventoryView: View {
     @ObservedObject var viewModel: PetViewModel
+    @StateObject private var adjustCtrl = ItemAdjustmentController()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -15,6 +17,9 @@ struct InventoryView: View {
             } else {
                 inventoryContent
             }
+        }
+        .onDisappear {
+            adjustCtrl.deactivate(viewModel: viewModel)
         }
     }
 
@@ -74,14 +79,46 @@ struct InventoryView: View {
                     viewModel: viewModel,
                     scale: 7.0,
                     interval: 0.5,
-                    isDraggable: true
+                    highlightedSlot: adjustCtrl.slot
                 )
-                // Shift down so hat pixels don't clip into the rounded corner
-                .offset(y: 6)
             }
             .frame(height: 128)
 
-            Text("아이템을 드래그하여 위치를 조정하세요 · 더블클릭으로 초기화")
+            positionHint
+        }
+    }
+
+    @ViewBuilder
+    private var positionHint: some View {
+        if let slot = adjustCtrl.slot {
+            let off = viewModel.equipmentOffset(for: slot)
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                    .font(.caption2)
+                    .foregroundStyle(.blue)
+                Text("← → ↑ ↓ 이동  ·  위치: (\(off.x), \(off.y))")
+                    .font(.caption2)
+                    .foregroundStyle(.blue)
+                Spacer()
+                Button("초기화") {
+                    viewModel.resetEquipmentOffset(for: slot)
+                }
+                .font(.caption2)
+                .foregroundStyle(.orange)
+                .buttonStyle(.plain)
+                Text("·")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Button("완료") {
+                    adjustCtrl.deactivate(viewModel: viewModel)
+                }
+                .font(.caption2.bold())
+                .foregroundStyle(.blue)
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 4)
+        } else {
+            Text("슬롯 옆 위치조정 아이콘을 눌러 키보드로 이동하세요")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -106,6 +143,7 @@ struct InventoryView: View {
 
     private func equippedSlotCard(_ slot: EquipmentSlot) -> some View {
         let item = viewModel.equippedItem(for: slot)
+        let isAdjusting = adjustCtrl.slot == slot
         return VStack(spacing: 4) {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -113,7 +151,12 @@ struct InventoryView: View {
                     .frame(height: 44)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .stroke(item != nil ? rarityColor(item!.rarity).opacity(0.4) : Color.clear, lineWidth: 1)
+                            .stroke(
+                                isAdjusting
+                                    ? Color.accentColor.opacity(0.6)
+                                    : (item != nil ? rarityColor(item!.rarity).opacity(0.4) : Color.clear),
+                                lineWidth: isAdjusting ? 1.5 : 1
+                            )
                     )
 
                 if let item {
@@ -138,13 +181,33 @@ struct InventoryView: View {
                 }
             }
 
-            Button("해제") {
-                if item != nil { viewModel.unequip(slot: slot) }
+            HStack(spacing: 6) {
+                Button("해제") {
+                    if item != nil { viewModel.unequip(slot: slot) }
+                }
+                .font(.system(size: 9))
+                .foregroundStyle(.red)
+                .buttonStyle(.plain)
+                .opacity(item != nil ? 1 : 0)
+
+                if item != nil {
+                    Button(action: {
+                        if isAdjusting {
+                            adjustCtrl.deactivate(viewModel: viewModel)
+                        } else {
+                            adjustCtrl.activate(slot: slot, viewModel: viewModel)
+                        }
+                    }) {
+                        Image(systemName: isAdjusting
+                              ? "scope"
+                              : "arrow.up.and.down.and.arrow.left.and.right")
+                            .font(.system(size: 9))
+                            .foregroundStyle(isAdjusting ? .blue : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(isAdjusting ? "위치 조정 완료" : "키보드로 위치 조정")
+                }
             }
-            .font(.system(size: 9))
-            .foregroundStyle(.red)
-            .buttonStyle(.plain)
-            .opacity(item != nil ? 1 : 0)
         }
         .frame(maxWidth: .infinity)
     }
@@ -231,6 +294,59 @@ struct InventoryView: View {
         case .hand:   return "손"
         case .effect: return "효과"
         }
+    }
+}
+
+// MARK: - Keyboard Adjustment Controller
+
+@MainActor
+private final class ItemAdjustmentController: ObservableObject {
+    @Published var slot: EquipmentSlot? = nil
+    private var monitor: Any?
+
+    func activate(slot: EquipmentSlot, viewModel: PetViewModel) {
+        deactivate(viewModel: viewModel)
+        self.slot = slot
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            MainActor.assumeIsolated {
+                guard let self, let s = self.slot else { return event }
+                switch event.keyCode {
+                case 123: // ← left
+                    let off = viewModel.equipmentOffset(for: s)
+                    viewModel.setEquipmentOffset(PixelOffset(x: off.x - 1, y: off.y), for: s)
+                    return nil
+                case 124: // → right
+                    let off = viewModel.equipmentOffset(for: s)
+                    viewModel.setEquipmentOffset(PixelOffset(x: off.x + 1, y: off.y), for: s)
+                    return nil
+                case 126: // ↑ up
+                    let off = viewModel.equipmentOffset(for: s)
+                    viewModel.setEquipmentOffset(PixelOffset(x: off.x, y: off.y - 1), for: s)
+                    return nil
+                case 125: // ↓ down
+                    let off = viewModel.equipmentOffset(for: s)
+                    viewModel.setEquipmentOffset(PixelOffset(x: off.x, y: off.y + 1), for: s)
+                    return nil
+                case 36, 76: // Return / numpad Enter
+                    self.deactivate(viewModel: viewModel)
+                    return nil
+                case 53: // Escape
+                    self.deactivate(viewModel: viewModel)
+                    return nil
+                default:
+                    return event
+                }
+            }
+        }
+    }
+
+    func deactivate(viewModel: PetViewModel) {
+        if let m = monitor { NSEvent.removeMonitor(m); monitor = nil }
+        if slot != nil { viewModel.save(); slot = nil }
+    }
+
+    deinit {
+        if let m = monitor { NSEvent.removeMonitor(m) }
     }
 }
 

--- a/Sources/DamagochiApp/Views/PopoverView.swift
+++ b/Sources/DamagochiApp/Views/PopoverView.swift
@@ -104,8 +104,6 @@ struct PopoverView: View {
                 scale: 8.0,
                 interval: 0.5
             )
-            // Shift down so hat pixels don't clip into the rounded corner at the top
-            .offset(y: 8)
             .modifier(StateAnimationModifier(state: viewModel.state))
 
             bugOverlay


### PR DESCRIPTION
- 슬롯별 위치조정 아이콘 추가: 각 장착 아이템 카드에 화살표 아이콘 버튼을 추가하여 클릭 시 해당 슬롯의 키보드 조정 모드 활성화
- 키보드 조정 모드: ← → ↑ ↓ 키로 1픽셀씩 이동, Enter/Escape로 완료, 초기화 버튼 제공
- 활성 슬롯 하이라이트: 조정 중인 아이템에 파란 점선 테두리 표시, 현재 오프셋 좌표 실시간 표시
- 드래그 인터페이스 제거: EquippedPetView에서 드래그 제스처 코드를 완전히 제거하고 highlightedSlot 파라미터로 대체
- 캐릭터 위치 조정: 메인 뷰에서 캐릭터가 어두운 패널 아래에서 약 1.25 스프라이트 픽셀 떠있도록 오프셋 제거

https://claude.ai/code/session_01RZkap11HEMpPwjjEnk5rCQ