### PR TITLE
Fix chat bubble stretching walking window; move character down

### DIFF
--- a/Sources/DamagochiApp/Views/WalkingPetView.swift
+++ b/Sources/DamagochiApp/Views/WalkingPetView.swift
@@ -7,10 +7,15 @@ struct WalkingPetView: View {
 
     var body: some View {
         VStack(spacing: 6) {
-            if let bubble = viewModel.walkSpeechBubble {
-                speechBubble(text: bubble)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+            // Fixed-height reservation for speech bubble — prevents window resize
+            ZStack(alignment: .top) {
+                Color.clear
+                if let bubble = viewModel.walkSpeechBubble {
+                    speechBubble(text: bubble)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
             }
+            .frame(height: 56)
 
             ZStack {
                 RoundedRectangle(cornerRadius: 14)
@@ -36,7 +41,7 @@ struct WalkingPetView: View {
                     .padding(.horizontal, 10)
                     .padding(.bottom, 8)
                 }
-                .padding(.top, 10)
+                .padding(.top, 20)
             }
             .frame(width: 130)
         }

--- a/Sources/DamagochiApp/Views/WalkingWindowController.swift
+++ b/Sources/DamagochiApp/Views/WalkingWindowController.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Combine
 import SwiftUI
 
 @MainActor
@@ -7,7 +6,6 @@ final class WalkingWindowController {
     private var panel: NSPanel?
     private var hostingController: NSHostingController<WalkingPetView>?
     private let viewModel: PetViewModel
-    private var cancellables: Set<AnyCancellable> = []
 
     init(viewModel: PetViewModel) {
         self.viewModel = viewModel
@@ -42,35 +40,11 @@ final class WalkingWindowController {
         panel.orderFront(nil)
         self.panel = panel
         self.hostingController = hostingController
-
-        viewModel.$walkSpeechBubble
-            .removeDuplicates { ($0 == nil) == ($1 == nil) }
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.resizePanelKeepingBottom()
-            }
-            .store(in: &cancellables)
     }
 
     func hide() {
-        cancellables.removeAll()
         panel?.close()
         panel = nil
         hostingController = nil
-    }
-
-    private func resizePanelKeepingBottom() {
-        guard let panel, let hostingController else { return }
-        // Wait one tick for SwiftUI to lay out the new content.
-        DispatchQueue.main.async { [weak panel, weak hostingController] in
-            guard let panel, let hostingController else { return }
-            let oldFrame = panel.frame
-            let newSize = hostingController.view.fittingSize
-            let newOrigin = NSPoint(
-                x: oldFrame.origin.x,
-                y: oldFrame.origin.y - (newSize.height - oldFrame.size.height)
-            )
-            panel.setFrame(NSRect(origin: newOrigin, size: newSize), display: true, animate: false)
-        }
     }
 }


### PR DESCRIPTION
Reserve a fixed 56pt height for the speech bubble area so the window
never resizes when a bubble appears or disappears. Remove the
dynamic resizePanelKeepingBottom logic that was causing vertical
stretching. Increase character top padding from 10→20pt to shift
it lower within the card.

https://claude.ai/code/session_01FTok8RKJSkaKcy6sqiEEtX