### PR TITLE
feat: 이사하기/이사오기 캐릭터 마이그레이션 기능

### DIFF
--- a/Sources/DamagochiApp/PetViewModel.swift
+++ b/Sources/DamagochiApp/PetViewModel.swift
@@ -418,6 +418,56 @@ final class PetViewModel: ObservableObject {
         showNotification("펫을 방생했습니다. 새 알이 생겼어요!", icon: "bird.fill")
     }
 
+    // MARK: - Migration
+
+    func exportPet() {
+        let panel = NSSavePanel()
+        panel.title = "이사하기 — 캐릭터 데이터 내보내기"
+        panel.nameFieldStringValue = "damagochi-pet.json"
+        panel.allowedContentTypes = [.json]
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try store.export(to: url)
+            showNotification("캐릭터 데이터를 내보냈습니다!", icon: "tray.and.arrow.up.fill")
+        } catch {
+            showNotification("내보내기 실패: \(error.localizedDescription)", icon: "exclamationmark.triangle.fill")
+        }
+    }
+
+    func importPet() {
+        let panel = NSOpenPanel()
+        panel.title = "이사오기 — 캐릭터 데이터 가져오기"
+        panel.allowedContentTypes = [.json]
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.urls.first else { return }
+        do {
+            var imported = try store.importState(from: url)
+
+            // 기존 펫이 있으면 방생 처리 후 묘지에 추가
+            let previousEntries = state.graveyardEntries
+            let previousDeathCount = state.deathCount
+            if state.phase == .alive || state.phase == .egg {
+                let entry = GraveyardEntry(from: state, cause: "이사")
+                imported.graveyardEntries = previousEntries + [entry] + imported.graveyardEntries
+            } else {
+                imported.graveyardEntries = previousEntries + imported.graveyardEntries
+            }
+            imported.deathCount = previousDeathCount + imported.deathCount
+
+            // 현재 머신 ID로 교체
+            imported.machineId = state.machineId
+
+            state = imported
+            save()
+            showNotification("이사 완료! 새 캐릭터로 시작합니다.", icon: "tray.and.arrow.down.fill")
+        } catch {
+            showNotification("가져오기 실패: \(error.localizedDescription)", icon: "exclamationmark.triangle.fill")
+        }
+    }
+
     // MARK: - Rebirth
 
     func rebirth() {

--- a/Sources/DamagochiApp/Views/SettingsView.swift
+++ b/Sources/DamagochiApp/Views/SettingsView.swift
@@ -4,6 +4,7 @@ import DamagochiCore
 struct SettingsView: View {
     @ObservedObject var viewModel: PetViewModel
     @State private var showReleaseConfirm = false
+    @State private var showImportConfirm = false
     @State private var commandCopied = false
 
     var body: some View {
@@ -47,6 +48,7 @@ struct SettingsView: View {
                     if viewModel.state.phase == .alive || viewModel.state.phase == .egg {
                         releaseSection
                     }
+                    migrationSection
                     appInfoSection
                 }
                 .padding(12)
@@ -62,6 +64,16 @@ struct SettingsView: View {
             Button("취소", role: .cancel) {}
         } message: {
             Text("현재 펫은 묘지에 기록되고 새로운 알이 생성됩니다.")
+        }
+        .confirmationDialog(
+            "이사오기",
+            isPresented: $showImportConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("이사오기", role: .destructive) { viewModel.importPet() }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("기존 캐릭터가 있으면 방생되고 가져온 캐릭터로 교체됩니다.")
         }
     }
 
@@ -168,6 +180,39 @@ struct SettingsView: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .tint(.teal)
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(0.3)))
+    }
+
+    // MARK: - Migration
+
+    private var migrationSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("이사하기 / 이사오기", systemImage: "arrow.left.arrow.right.circle.fill")
+                .font(.caption.bold())
+
+            Text("다른 PC로 캐릭터를 옮기거나 다른 계정의 캐릭터를 가져옵니다.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                Button(action: { viewModel.exportPet() }) {
+                    Label("이사하기", systemImage: "tray.and.arrow.up.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.blue)
+
+                Button(action: { showImportConfirm = true }) {
+                    Label("이사오기", systemImage: "tray.and.arrow.down.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.orange)
+            }
         }
         .padding(10)
         .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary.opacity(0.3)))

--- a/Sources/DamagochiStorage/PetStore.swift
+++ b/Sources/DamagochiStorage/PetStore.swift
@@ -1,6 +1,18 @@
 import Foundation
 import DamagochiCore
 
+public enum MigrationError: LocalizedError {
+    case noData
+    case invalidFile
+
+    public var errorDescription: String? {
+        switch self {
+        case .noData:       return "저장된 펫 데이터가 없습니다."
+        case .invalidFile:  return "올바른 다마고치 데이터 파일이 아닙니다."
+        }
+    }
+}
+
 public final class PetStore: Sendable {
     private static let stateKey = "com.damagochi.petState"
 
@@ -18,5 +30,21 @@ public final class PetStore: Sendable {
 
     public func reset() {
         UserDefaults.standard.removeObject(forKey: Self.stateKey)
+    }
+
+    public func export(to url: URL) throws {
+        guard let state = load() else { throw MigrationError.noData }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(state)
+        try data.write(to: url, options: .atomic)
+    }
+
+    public func importState(from url: URL) throws -> PetState {
+        let data = try Data(contentsOf: url)
+        guard let state = try? JSONDecoder().decode(PetState.self, from: data) else {
+            throw MigrationError.invalidFile
+        }
+        return state
     }
 }


### PR DESCRIPTION
## Summary

- 설정 탭에 **이사하기 / 이사오기** 섹션 추가
- **이사하기**: 현재 캐릭터 데이터(레벨, 장비, XP, 스탯 등 전체)를 JSON 파일로 내보내기
- **이사오기**: JSON 파일을 가져와 캐릭터 교체 (기존 캐릭터는 묘지에 '이사' 사유로 기록, 묘지/사망 횟수 누적)

## Test plan

- [ ] 이사하기 버튼 클릭 → NSSavePanel 표시 → JSON 파일 저장 확인
- [ ] 이사오기 버튼 클릭 → 확인 다이얼로그 표시 → NSOpenPanel → 캐릭터 교체 확인
- [ ] 기존 캐릭터 있을 때 이사오기 시 묘지에 기록되는지 확인
- [ ] 다른 PC에서 내보낸 파일 가져왔을 때 머신 ID가 현재 PC로 교체되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)